### PR TITLE
feat: 회원가입 API

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -38,6 +38,7 @@
 				"@nestjs/cli": "^9.0.0",
 				"@nestjs/schematics": "^9.0.0",
 				"@nestjs/testing": "^9.0.0",
+				"@types/bcryptjs": "^2.4.6",
 				"@types/express": "^4.17.13",
 				"@types/jest": "29.5.1",
 				"@types/node": "^18.16.12",
@@ -2040,6 +2041,12 @@
 			"dependencies": {
 				"@babel/types": "^7.20.7"
 			}
+		},
+		"node_modules/@types/bcryptjs": {
+			"version": "2.4.6",
+			"resolved": "https://registry.npmjs.org/@types/bcryptjs/-/bcryptjs-2.4.6.tgz",
+			"integrity": "sha512-9xlo6R2qDs5uixm0bcIqCeMCE6HiQsIyel9KQySStiyqNl2tnj2mP3DX1Nf56MD6KMenNNlBBsy3LJ7gUEQPXQ==",
+			"dev": true
 		},
 		"node_modules/@types/body-parser": {
 			"version": "1.19.5",

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
 		"@nestjs/cli": "^9.0.0",
 		"@nestjs/schematics": "^9.0.0",
 		"@nestjs/testing": "^9.0.0",
+		"@types/bcryptjs": "^2.4.6",
 		"@types/express": "^4.17.13",
 		"@types/jest": "29.5.1",
 		"@types/node": "^18.16.12",

--- a/src/users/dto/create-user.dto.ts
+++ b/src/users/dto/create-user.dto.ts
@@ -1,0 +1,15 @@
+import { IsNotEmpty, IsString, Matches } from 'class-validator';
+
+export class CreateUserDto {
+	@IsNotEmpty({ message: 'account 필드는 필수 입력 필드입니다.' })
+	@IsString({ message: 'account 필드에 문자열을 입력해야 합니다.' })
+	account: string;
+
+	@IsNotEmpty({ message: 'password 필드는 필수 입력 필드입니다.' })
+	@IsString({ message: 'password 필드에 문자열을 입력해야 합니다.' })
+	@Matches(/^(?=.*[a-zA-Z])(?=.*[0-9])(?=.*[!@#$%^&*?_]).{8,16}$/, {
+		message:
+			'패스워드는 8~16자리이며 최소 하나 이상의 영문자, 최소 하나 이상의 숫자, 최소 하나 이상의 특수문자를 입력해야 합니다.',
+	})
+	password: string;
+}

--- a/src/users/dto/index.ts
+++ b/src/users/dto/index.ts
@@ -1,0 +1,1 @@
+export * from './create-user.dto';

--- a/src/users/enums/index.ts
+++ b/src/users/enums/index.ts
@@ -1,0 +1,2 @@
+export * from './user-exception.enum';
+export * from './user-response.enum';

--- a/src/users/enums/user-exception.enum.ts
+++ b/src/users/enums/user-exception.enum.ts
@@ -1,0 +1,3 @@
+export enum UserException {
+	ACCOUNT_ALREADY_EXISTS = '이미 존재하는 계정입니다.',
+}

--- a/src/users/enums/user-response.enum.ts
+++ b/src/users/enums/user-response.enum.ts
@@ -1,0 +1,3 @@
+export enum UserResponse {
+	CREATE_USER = '회원가입 성공',
+}

--- a/src/users/pipes/check-account.pipe.ts
+++ b/src/users/pipes/check-account.pipe.ts
@@ -1,0 +1,21 @@
+import { ConflictException, Injectable, PipeTransform } from '@nestjs/common';
+import { CreateUserDto } from '../dto';
+import { UsersService } from '../users.service';
+import { UserException } from '../enums';
+
+@Injectable()
+export class CheckAccountPipe implements PipeTransform {
+	constructor(
+		private readonly usersSerivce: UsersService, //
+	) {}
+
+	async transform(value: CreateUserDto) {
+		const { account } = value;
+		const userExist = await this.usersSerivce.isUserExist({ account });
+		if (userExist) {
+			throw new ConflictException(UserException.ACCOUNT_ALREADY_EXISTS);
+		}
+
+		return value;
+	}
+}

--- a/src/users/pipes/index.ts
+++ b/src/users/pipes/index.ts
@@ -1,0 +1,1 @@
+export * from './check-account.pipe';

--- a/src/users/users.controller.ts
+++ b/src/users/users.controller.ts
@@ -1,9 +1,21 @@
-import { Controller } from '@nestjs/common';
+import { Body, Controller, Post } from '@nestjs/common';
 import { UsersService } from './users.service';
+import { CreateUserDto } from './dto';
+import { CheckAccountPipe } from './pipes';
+import { ResponseMessage } from 'src/global';
+import { UserResponse } from './enums';
 
 @Controller('users')
 export class UsersController {
 	constructor(
 		private readonly usersService: UsersService, //
 	) {}
+
+	@Post()
+	@ResponseMessage(UserResponse.CREATE_USER)
+	async createUser(
+		@Body(CheckAccountPipe) createUserDto: CreateUserDto, //
+	) {
+		return await this.usersService.createUser(createUserDto);
+	}
 }

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -1,7 +1,9 @@
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { User } from './entity';
-import { Repository } from 'typeorm';
+import { FindOptionsWhere, Repository } from 'typeorm';
+import { CreateUserDto } from './dto';
+import * as bcrypt from 'bcryptjs';
 
 @Injectable()
 export class UsersService {
@@ -9,4 +11,18 @@ export class UsersService {
 		@InjectRepository(User)
 		private readonly usersRepository: Repository<User>, //
 	) {}
+
+	async isUserExist(where: FindOptionsWhere<User>): Promise<boolean> {
+		return await this.usersRepository.exist({ where });
+	}
+
+	async createUser(createUserDto: CreateUserDto) {
+		const { account, password: plainPassword } = createUserDto;
+		const password = await bcrypt.hash(plainPassword, 10);
+
+		await this.usersRepository.save({
+			account,
+			password,
+		});
+	}
 }


### PR DESCRIPTION
- CreateUserDto 추가
  - account, password 필드 유효성 검사
- CheckAccountPipe 추가
  - account 필드에 해당하는 유저가 존재하는지 확인하는 파이프
- createUser 라우트 핸들러 추가
  - POST /users
  - 회원가입 API
  - createUserDto 파라미터에 CheckAccountPipe 적용
  - '회원가입 성공' 메세지 응답(ResponseMessage 데코레이터)
- createUser 서비스 로직 추가
  - password 해시 후 유저 정보 저장
- isUserExist 서비스 로직 추가
  - FindOptionsWhere<User>로 유저 레코드가 존재하는지 확인
- UserException enum 추가
  - 유저 관련 예외 메세지를 담고 있는 enum
- UserResponse enum 추가
  - 유저 관련 성공 응답 메세지를 담고 있는 enum