### PR TITLE
fix: 유저 엔티티 수정, 유저 엔티티 수정에 따른 로직들 수정

### DIFF
--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -20,8 +20,8 @@ export class AuthService {
 		return await bcrypt.compare(plainPassword, hashedPassword);
 	}
 
-	async validateUser(account: string, password: string) {
-		const user = await this.usersService.findOne({ account });
+	async validateUser(username: string, password: string) {
+		const user = await this.usersService.findOne({ username });
 		if (!user) {
 			throw new NotFoundException(AuthException.USER_NOT_EXISTS);
 		}
@@ -34,10 +34,10 @@ export class AuthService {
 	}
 
 	async login(user: User) {
-		const { id, account } = user;
+		const { id, username } = user;
 
-		const accessToken = this.generateAccessToken({ id, account });
-		const refreshToken = this.generateRefreshToken({ id, account });
+		const accessToken = this.generateAccessToken({ id, username });
+		const refreshToken = this.generateRefreshToken({ id, username });
 
 		user.refreshToken = refreshToken;
 		await this.usersService.updateOne({ id }, user);

--- a/src/global/interfaces/token.payload.ts
+++ b/src/global/interfaces/token.payload.ts
@@ -1,4 +1,4 @@
 export interface TokenPayload {
 	id: string;
-	account: string;
+	username: string;
 }

--- a/src/users/dto/create-user.dto.ts
+++ b/src/users/dto/create-user.dto.ts
@@ -1,9 +1,9 @@
 import { IsNotEmpty, IsString, Matches } from 'class-validator';
 
 export class CreateUserDto {
-	@IsNotEmpty({ message: 'account 필드는 필수 입력 필드입니다.' })
-	@IsString({ message: 'account 필드에 문자열을 입력해야 합니다.' })
-	account: string;
+	@IsNotEmpty({ message: 'username 필드는 필수 입력 필드입니다.' })
+	@IsString({ message: 'username 필드에 문자열을 입력해야 합니다.' })
+	username: string;
 
 	@IsNotEmpty({ message: 'password 필드는 필수 입력 필드입니다.' })
 	@IsString({ message: 'password 필드에 문자열을 입력해야 합니다.' })

--- a/src/users/entity/user.entity.ts
+++ b/src/users/entity/user.entity.ts
@@ -4,7 +4,7 @@ import { Column, Entity } from 'typeorm';
 @Entity()
 export class User extends BaseEntity {
 	@Column({ unique: true })
-	account: string;
+	username: string;
 
 	@Column()
 	password: string;

--- a/src/users/pipes/check-account.pipe.ts
+++ b/src/users/pipes/check-account.pipe.ts
@@ -10,8 +10,8 @@ export class CheckAccountPipe implements PipeTransform {
 	) {}
 
 	async transform(value: CreateUserDto) {
-		const { account } = value;
-		const userExist = await this.usersSerivce.isUserExist({ account });
+		const { username } = value;
+		const userExist = await this.usersSerivce.isUserExist({ username });
 		if (userExist) {
 			throw new ConflictException(UserException.ACCOUNT_ALREADY_EXISTS);
 		}

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -17,11 +17,11 @@ export class UsersService {
 	}
 
 	async createUser(createUserDto: CreateUserDto) {
-		const { account, password: plainPassword } = createUserDto;
+		const { username, password: plainPassword } = createUserDto;
 		const password = await bcrypt.hash(plainPassword, 10);
 
 		await this.usersRepository.save({
-			account,
+			username,
 			password,
 		});
 	}


### PR DESCRIPTION
유저 엔티티 수정
- account 필드를 username 필드로 수정

유저 엔티티 수정에 따른 로직들 수정
- CreateUserDto
  - account 필드를 username 필드로 수정
- TokenPayload
  - account 프로퍼티를 username 프로퍼티로 수정
- CheckAccountPipe
  - account 필드 조회에서 username 필드 조회로 수정
- AuthService
  - validateUser: account 필드 조회에서 username 필드 조회로 수정
  - login: 액세스 토큰 및 리프레시 토큰 생성 시 account 대신 username를 페이로드에 추가
- UsersService
  - createUser: account 필드 저장에서 username 필드 저장으로 수정

#6 