### PR TITLE
feat: 로그인 dto 추가 및 로그인 dto 유효성 검사

### DIFF
--- a/src/auth/dto/index.ts
+++ b/src/auth/dto/index.ts
@@ -1,0 +1,1 @@
+export * from './login.dto';

--- a/src/auth/dto/login.dto.ts
+++ b/src/auth/dto/login.dto.ts
@@ -1,0 +1,3 @@
+import { CreateUserDto } from 'src/users';
+
+export class LogInDto extends CreateUserDto {}

--- a/src/auth/guards/local-login-auth.guard.ts
+++ b/src/auth/guards/local-login-auth.guard.ts
@@ -1,5 +1,29 @@
-import { Injectable } from '@nestjs/common';
+import { BadRequestException, ExecutionContext, Injectable } from '@nestjs/common';
 import { AuthGuard } from '@nestjs/passport';
+import { plainToClass } from 'class-transformer';
+import { Request } from 'express';
+import { LogInDto } from '../dto';
+import { validate } from 'class-validator';
 
 @Injectable()
-export class LocalLoginAuthGuard extends AuthGuard('local') {}
+export class LocalLoginAuthGuard extends AuthGuard('local') {
+	async canActivate(context: ExecutionContext): Promise<boolean> {
+		const request = context.switchToHttp().getRequest<Request>();
+
+		// 요청 객체의 바디를 클래스 인스턴스로 변경
+		const body = plainToClass(LogInDto, request.body);
+
+		// 요청 바디의 유효성을 검사하여 에러 리스트 가져오기
+		const errors = await validate(body);
+
+		// 에러 메세지가 추출된다면 유효성 검사 실패
+		const errorMessages = errors.flatMap(({ constraints }) => Object.values(constraints));
+
+		// 유효성 검사 실패 시 BadRequest 응답
+		if (errorMessages.length > 0) {
+			throw new BadRequestException(errorMessages);
+		}
+
+		return super.canActivate(context) as Promise<boolean>;
+	}
+}


### PR DESCRIPTION
로그인 dto 추가
- CreateUserDto를 상속하는 LogInDto 추가

로그인 dto 유효성 검사
- LocalLoginAuthGuard의 canActivate 메서드에서 LogInDto의 유효성 검사 진행
- 유효성 검사가 실패하는 경우 BadRequest 응답

#10 