### PR TITLE
feat: 액세스 토큰 재발급 API, 로그아웃 API

### DIFF
--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -1,11 +1,12 @@
-import { Controller, Post, UseGuards } from '@nestjs/common';
-import { LocalLoginAuthGuard } from './guards';
-import { GetUser, ResponseMessage } from 'src/global';
+import { Controller, HttpCode, Post, UseFilters, UseGuards } from '@nestjs/common';
+import { AccessTokenGuard, LocalLoginAuthGuard, RefreshTokenGuard } from './guards';
+import { GetUser, JwtExceptionFilter, ResponseMessage } from 'src/global';
 import { User } from 'src/users';
 import { AuthService } from './auth.service';
 import { AuthResponse } from './enums';
 
 @Controller('auth')
+@UseFilters(JwtExceptionFilter)
 export class AuthController {
 	constructor(
 		private readonly authService: AuthService, //
@@ -18,5 +19,25 @@ export class AuthController {
 		@GetUser() user: User, //
 	) {
 		return await this.authService.login(user);
+	}
+
+	@Post('logout')
+	@UseGuards(AccessTokenGuard)
+	@ResponseMessage(AuthResponse.LOGOUT)
+	@HttpCode(200)
+	async logout(
+		@GetUser() user: User, //
+	) {
+		return await this.authService.logout(user);
+	}
+
+	@Post('refresh')
+	@UseGuards(RefreshTokenGuard)
+	@ResponseMessage(AuthResponse.REFRESH)
+	@HttpCode(200)
+	refresh(
+		@GetUser() user: User, //
+	) {
+		return this.authService.refresh(user);
 	}
 }

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -48,6 +48,20 @@ export class AuthService {
 		};
 	}
 
+	async logout(user: User) {
+		await this.usersService.updateOne({ id: user.id }, { refreshToken: null });
+	}
+
+	refresh(user: User) {
+		return {
+			accessToken: this.generateAccessToken({ id: user.id, username: user.username }),
+		};
+	}
+
+	async checkAlreadyLogOut(id: string): Promise<User | null> {
+		return await this.usersService.findOne({ id });
+	}
+
 	generateAccessToken(payload: TokenPayload): string {
 		return this.jwtService.sign(payload, {
 			secret: this.config.access.secret,

--- a/src/auth/enums/auth-response.enum.ts
+++ b/src/auth/enums/auth-response.enum.ts
@@ -1,3 +1,5 @@
 export enum AuthResponse {
 	LOGIN = '로그인 성공',
+	LOGOUT = '로그아웃 성공',
+	REFRESH = '액세스 토큰 재발급 성공',
 }

--- a/src/auth/strategies/access-token.strategy.ts
+++ b/src/auth/strategies/access-token.strategy.ts
@@ -4,12 +4,16 @@ import { PassportStrategy } from '@nestjs/passport';
 import { ExtractJwt, Strategy } from 'passport-jwt';
 import { TokenPayload } from 'src/global';
 import jwtConfiguration from 'src/global/configs/jwt.configuration';
+import { AuthService } from '../auth.service';
+import { JsonWebTokenError } from 'jsonwebtoken';
+import { AuthException } from '../enums';
 
 @Injectable()
 export class AccessTokenStrategy extends PassportStrategy(Strategy, 'access') {
 	constructor(
 		@Inject(jwtConfiguration.KEY)
 		private readonly config: ConfigType<typeof jwtConfiguration>,
+		private readonly authService: AuthService,
 	) {
 		super({
 			jwtFromRequest: ExtractJwt.fromAuthHeaderAsBearerToken(),
@@ -17,7 +21,14 @@ export class AccessTokenStrategy extends PassportStrategy(Strategy, 'access') {
 		});
 	}
 
-	validate(payload: TokenPayload) {
+	async validate(payload: TokenPayload) {
+		// 1. 로그아웃 시 refreshToken을 null로 설정
+		// 2. 로그아웃 시 사용한 액세스 토큰으로 재요청하면 refreshToken을 확인해 유효하지 않은 액세스 토큰으로 판단
+		const { refreshToken } = await this.authService.checkAlreadyLogOut(payload.id);
+		if (!refreshToken) {
+			throw new JsonWebTokenError(AuthException.INVALID_ACCESS_TOKEN);
+		}
+
 		return payload;
 	}
 }

--- a/src/auth/strategies/refresh-token.strategy.ts
+++ b/src/auth/strategies/refresh-token.strategy.ts
@@ -4,12 +4,16 @@ import { PassportStrategy } from '@nestjs/passport';
 import { ExtractJwt, Strategy } from 'passport-jwt';
 import { TokenPayload } from 'src/global';
 import jwtConfiguration from 'src/global/configs/jwt.configuration';
+import { AuthService } from '../auth.service';
+import { JsonWebTokenError } from 'jsonwebtoken';
+import { AuthException } from '../enums';
 
 @Injectable()
 export class RefreshTokenStrategy extends PassportStrategy(Strategy, 'refresh') {
 	constructor(
 		@Inject(jwtConfiguration.KEY)
 		private readonly config: ConfigType<typeof jwtConfiguration>,
+		private readonly authService: AuthService,
 	) {
 		super({
 			jwtFromRequest: ExtractJwt.fromAuthHeaderAsBearerToken(),
@@ -17,7 +21,14 @@ export class RefreshTokenStrategy extends PassportStrategy(Strategy, 'refresh') 
 		});
 	}
 
-	validate(payload: TokenPayload) {
+	async validate(payload: TokenPayload) {
+		// 1. 로그아웃 시 refreshToken을 null로 설정
+		// 2. 로그아웃 시 사용한 액세스 토큰으로 재요청하면 refreshToken을 확인해 유효하지 않은 액세스 토큰으로 판단
+		const { refreshToken } = await this.authService.checkAlreadyLogOut(payload.id);
+		if (!refreshToken) {
+			throw new JsonWebTokenError(AuthException.INVALID_ACCESS_TOKEN);
+		}
+
 		return payload;
 	}
 }

--- a/src/global/filters/jwt-exception.filter.ts
+++ b/src/global/filters/jwt-exception.filter.ts
@@ -8,7 +8,7 @@ export class JwtExceptionFilter implements ExceptionFilter {
 		const ctx = host.switchToHttp();
 		const response = ctx.getResponse<Response>();
 		const request = ctx.getRequest<Request>();
-		const status = HttpStatus.BAD_REQUEST;
+		const status = HttpStatus.UNAUTHORIZED;
 
 		response.status(status).json({
 			success: false,


### PR DESCRIPTION
- 액세스 토큰 재발급 API
  - POST /auth/refresh
  - refresh 라우트 핸들러
  - RefreshTokenGuard 적용
  - refresh 서비스 로직을 통해 액세스 토큰 재발급
- 로그아웃 API
  - POST /auth/login
  - logout 라우트 핸들러
  - AccessTokenGuard 적용
  - logout 서비스 로직을 통해 유저의 refreshToken 값을 null로 설정

#7 