### PR TITLE
fix: 액세스토큰 가드/전략, 리프레시토큰 가드/전략

### DIFF
--- a/src/auth/guards/access-token.guard.ts
+++ b/src/auth/guards/access-token.guard.ts
@@ -1,15 +1,10 @@
-import { ExecutionContext, Injectable } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
 import { AuthGuard } from '@nestjs/passport';
 import { JsonWebTokenError } from 'jsonwebtoken';
-import { Observable } from 'rxjs';
 import { AuthException } from '../enums';
 
 @Injectable()
 export class AccessTokenGuard extends AuthGuard('access') {
-	canActivate(context: ExecutionContext): boolean | Promise<boolean> | Observable<boolean> {
-		return super.canActivate(context);
-	}
-
 	handleRequest(err: any, user: any) {
 		if (err || !user) {
 			throw new JsonWebTokenError(AuthException.INVALID_ACCESS_TOKEN);

--- a/src/auth/guards/refresh-token.guard.ts
+++ b/src/auth/guards/refresh-token.guard.ts
@@ -1,15 +1,10 @@
-import { ExecutionContext, Injectable } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
 import { AuthGuard } from '@nestjs/passport';
 import { JsonWebTokenError } from 'jsonwebtoken';
-import { Observable } from 'rxjs';
 import { AuthException } from '../enums';
 
 @Injectable()
 export class RefreshTokenGuard extends AuthGuard('refresh') {
-	canActivate(context: ExecutionContext): boolean | Promise<boolean> | Observable<boolean> {
-		return super.canActivate(context);
-	}
-
 	handleRequest(err: any, user: any) {
 		if (err || !user) {
 			throw new JsonWebTokenError(AuthException.INVALID_REFRESH_TOKEN);

--- a/src/auth/strategies/access-token.strategy.ts
+++ b/src/auth/strategies/access-token.strategy.ts
@@ -5,8 +5,6 @@ import { ExtractJwt, Strategy } from 'passport-jwt';
 import { TokenPayload } from 'src/global';
 import jwtConfiguration from 'src/global/configs/jwt.configuration';
 import { AuthService } from '../auth.service';
-import { JsonWebTokenError } from 'jsonwebtoken';
-import { AuthException } from '../enums';
 
 @Injectable()
 export class AccessTokenStrategy extends PassportStrategy(Strategy, 'access') {
@@ -22,11 +20,12 @@ export class AccessTokenStrategy extends PassportStrategy(Strategy, 'access') {
 	}
 
 	async validate(payload: TokenPayload) {
-		// 1. 로그아웃 시 refreshToken을 null로 설정
-		// 2. 로그아웃 시 사용한 액세스 토큰으로 재요청하면 refreshToken을 확인해 유효하지 않은 액세스 토큰으로 판단
+		// 1. 로그아웃 시 refreshToken을 null로 설정하여 로그아웃 상태임을 저장
+		// 2. 로그아웃 시 사용했지만 아직 만료시간이 되지 않아 여전히 유효한 액세스 토큰으로 재요청하면 DB에 저장된 refreshToken을 확인
+		// 3. refreshToken이 null이라면 유효하지 않은 액세스 토큰으로 판단
 		const { refreshToken } = await this.authService.checkAlreadyLogOut(payload.id);
 		if (!refreshToken) {
-			throw new JsonWebTokenError(AuthException.INVALID_ACCESS_TOKEN);
+			return false;
 		}
 
 		return payload;

--- a/src/auth/strategies/refresh-token.strategy.ts
+++ b/src/auth/strategies/refresh-token.strategy.ts
@@ -5,8 +5,6 @@ import { ExtractJwt, Strategy } from 'passport-jwt';
 import { TokenPayload } from 'src/global';
 import jwtConfiguration from 'src/global/configs/jwt.configuration';
 import { AuthService } from '../auth.service';
-import { JsonWebTokenError } from 'jsonwebtoken';
-import { AuthException } from '../enums';
 
 @Injectable()
 export class RefreshTokenStrategy extends PassportStrategy(Strategy, 'refresh') {
@@ -22,11 +20,12 @@ export class RefreshTokenStrategy extends PassportStrategy(Strategy, 'refresh') 
 	}
 
 	async validate(payload: TokenPayload) {
-		// 1. 로그아웃 시 refreshToken을 null로 설정
-		// 2. 로그아웃 시 사용한 액세스 토큰으로 재요청하면 refreshToken을 확인해 유효하지 않은 액세스 토큰으로 판단
+		// 1. 로그아웃 시 refreshToken을 null로 설정하여 로그아웃 상태임을 저장
+		// 2. 로그아웃했지만 아직 만료시간이 되지 않아 여전히 유효한 리프레시 토큰으로 액세스 토큰 재발급 요청 시 DB에 저장된 refreshToken을 확인
+		// 3. refreshToken이 null이라면 유효하지 않은 리프레시 토큰으로 판단
 		const { refreshToken } = await this.authService.checkAlreadyLogOut(payload.id);
 		if (!refreshToken) {
-			throw new JsonWebTokenError(AuthException.INVALID_ACCESS_TOKEN);
+			return false;
 		}
 
 		return payload;


### PR DESCRIPTION
액세스토큰 가드, 리프레시토큰 가드 수정
- 두 토큰 가드의 canActivate 메서드 제거

액세스토큰 전략, 리프레시토큰 전략 validate 메서드 수정
- 액세스토큰 전략 validate 메서드 수정
  - 로그아웃 시 refreshToken을 null로 설정하여 로그아웃 상태임을 저장
  - 로그아웃 시 사용했지만 아직 만료시간이 되지 않아 여전히 유효한 액세스 토큰으로 재요청하면 DB에 저장된 refreshToken을 확인
  - refreshToken이 null이라면 유효하지 않은 액세스 토큰으로 판단
    
- 리프레시토큰 전략 validate 메서드 수정
  - 로그아웃 시 refreshToken을 null로 설정하여 로그아웃 상태임을 저장
  - 로그아웃했지만 아직 만료시간이 되지 않아 여전히 유효한 리프레시 토큰으로 액세스 토큰 재발급 요청 시 DB에 저장된 refreshToken을 확인
  - refreshToken이 null이라면 유효하지 않은 리프레시 토큰으로 판단

#16 