### PR TITLE
feat: 카테고리 모듈 생성, 카테고리 엔티티 생성

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -5,6 +5,7 @@ import { validationSchema } from './global/configs/validation.schema';
 import { UsersModule } from './users/users.module';
 import jwtConfiguration from './global/configs/jwt.configuration';
 import { AuthModule } from './auth';
+import { CategoriesModule } from './categories/categories.module';
 
 @Module({
 	imports: [
@@ -18,6 +19,7 @@ import { AuthModule } from './auth';
 		DatabaseModule,
 		UsersModule,
 		AuthModule,
+		CategoriesModule,
 	],
 })
 export class AppModule {}

--- a/src/categories/categories.controller.ts
+++ b/src/categories/categories.controller.ts
@@ -1,0 +1,9 @@
+import { Controller } from '@nestjs/common';
+import { CategoriesService } from './categories.service';
+
+@Controller('categories')
+export class CategoriesController {
+	constructor(
+		private readonly categoriesService: CategoriesService, //
+	) {}
+}

--- a/src/categories/categories.module.ts
+++ b/src/categories/categories.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { CategoriesController } from './categories.controller';
+import { CategoriesService } from './categories.service';
+
+@Module({
+	controllers: [CategoriesController],
+	providers: [CategoriesService],
+})
+export class CategoriesModule {}

--- a/src/categories/categories.module.ts
+++ b/src/categories/categories.module.ts
@@ -1,8 +1,11 @@
 import { Module } from '@nestjs/common';
 import { CategoriesController } from './categories.controller';
 import { CategoriesService } from './categories.service';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Category } from './entity';
 
 @Module({
+	imports: [TypeOrmModule.forFeature([Category])],
 	controllers: [CategoriesController],
 	providers: [CategoriesService],
 })

--- a/src/categories/categories.service.ts
+++ b/src/categories/categories.service.ts
@@ -1,0 +1,4 @@
+import { Injectable } from '@nestjs/common';
+
+@Injectable()
+export class CategoriesService {}

--- a/src/categories/categories.service.ts
+++ b/src/categories/categories.service.ts
@@ -1,4 +1,23 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, OnModuleInit } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Category } from './entity';
+import { Repository } from 'typeorm';
+import { CategoryName } from 'src/global';
 
 @Injectable()
-export class CategoriesService {}
+export class CategoriesService implements OnModuleInit {
+	constructor(
+		@InjectRepository(Category)
+		private readonly categoriesRepository: Repository<Category>, //
+	) {}
+
+	async onModuleInit(): Promise<void> {
+		const categoryNames = Object.values(CategoryName).map((name) => {
+			return { name };
+		});
+		await this.categoriesRepository.upsert(categoryNames, {
+			conflictPaths: ['name'],
+			skipUpdateIfNoValuesChanged: true,
+		});
+	}
+}

--- a/src/categories/entity/category.entity.ts
+++ b/src/categories/entity/category.entity.ts
@@ -1,0 +1,8 @@
+import { BaseEntity, CategoryName } from 'src/global';
+import { Column, Entity } from 'typeorm';
+
+@Entity()
+export class Category extends BaseEntity {
+	@Column({ type: 'enum', enum: CategoryName, unique: true })
+	name: CategoryName;
+}

--- a/src/categories/entity/index.ts
+++ b/src/categories/entity/index.ts
@@ -1,0 +1,1 @@
+export * from './category.entity';

--- a/src/categories/index.ts
+++ b/src/categories/index.ts
@@ -1,0 +1,3 @@
+export * from './categories.module';
+export * from './categories.service';
+export * from './entity';

--- a/src/global/enums/category-name.enum.ts
+++ b/src/global/enums/category-name.enum.ts
@@ -1,0 +1,10 @@
+export enum CategoryName {
+	FOOD = 'food',
+	CAFE = 'cafe',
+	TRANSPORT = 'transport',
+	LIVING = 'living',
+	SHOP = 'shop',
+	HOBBY = 'hobby',
+	HEALTH = 'health',
+	CULTURE = 'culture',
+}

--- a/src/global/enums/index.ts
+++ b/src/global/enums/index.ts
@@ -1,0 +1,1 @@
+export * from './category-name.enum';

--- a/src/global/index.ts
+++ b/src/global/index.ts
@@ -4,3 +4,4 @@ export * from './entities';
 export * from './filters';
 export * from './interceptors';
 export * from './interfaces';
+export * from './enums';

--- a/test/categories/categories.controller.spec.ts
+++ b/test/categories/categories.controller.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { CategoriesController } from '../../src/categories/categories.controller';
+
+describe('CategoriesController', () => {
+	let controller: CategoriesController;
+
+	beforeEach(async () => {
+		const module: TestingModule = await Test.createTestingModule({
+			controllers: [CategoriesController],
+		}).compile();
+
+		controller = module.get<CategoriesController>(CategoriesController);
+	});
+
+	it('should be defined', () => {
+		expect(controller).toBeDefined();
+	});
+});

--- a/test/categories/categories.service.spec.ts
+++ b/test/categories/categories.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { CategoriesService } from '../../src/categories/categories.service';
+
+describe('CategoriesService', () => {
+	let service: CategoriesService;
+
+	beforeEach(async () => {
+		const module: TestingModule = await Test.createTestingModule({
+			providers: [CategoriesService],
+		}).compile();
+
+		service = module.get<CategoriesService>(CategoriesService);
+	});
+
+	it('should be defined', () => {
+		expect(service).toBeDefined();
+	});
+});


### PR DESCRIPTION
카테고리 엔티티
- BaseEntity 상속
- name 칼럼
  - CategoryName enum 타입 설정
  - unique 제약조건 추가

카테고리 서비스
- onModuleInit 메서드
  - 카테고리 모듈 초기화 시 CategoryName enum의 값으로 DB에 upsert 쿼리 수행

#14 