### PR TITLE
feat: 카테고리별 예산 모듈, 카테고리별 예산 엔티티

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -7,6 +7,7 @@ import jwtConfiguration from './global/configs/jwt.configuration';
 import { AuthModule } from './auth';
 import { CategoriesModule } from './categories/categories.module';
 import { BudgetsModule } from './budgets';
+import { CategoryBudgetsModule } from './category-budgets';
 
 @Module({
 	imports: [
@@ -22,6 +23,7 @@ import { BudgetsModule } from './budgets';
 		AuthModule,
 		CategoriesModule,
 		BudgetsModule,
+		CategoryBudgetsModule,
 	],
 })
 export class AppModule {}

--- a/src/budgets/index.ts
+++ b/src/budgets/index.ts
@@ -1,1 +1,3 @@
 export * from './budgets.module';
+export * from './budgets.service';
+export * from './entity';

--- a/src/category-budgets/category-budgets.module.ts
+++ b/src/category-budgets/category-budgets.module.ts
@@ -1,7 +1,10 @@
 import { Module } from '@nestjs/common';
 import { CategoryBudgetsService } from './category-budgets.service';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { CategoryBudget } from './entity';
 
 @Module({
+	imports: [TypeOrmModule.forFeature([CategoryBudget])],
 	providers: [CategoryBudgetsService],
 })
 export class CategoryBudgetsModule {}

--- a/src/category-budgets/category-budgets.module.ts
+++ b/src/category-budgets/category-budgets.module.ts
@@ -1,0 +1,7 @@
+import { Module } from '@nestjs/common';
+import { CategoryBudgetsService } from './category-budgets.service';
+
+@Module({
+	providers: [CategoryBudgetsService],
+})
+export class CategoryBudgetsModule {}

--- a/src/category-budgets/category-budgets.service.ts
+++ b/src/category-budgets/category-budgets.service.ts
@@ -1,0 +1,4 @@
+import { Injectable } from '@nestjs/common';
+
+@Injectable()
+export class CategoryBudgetsService {}

--- a/src/category-budgets/category-budgets.service.ts
+++ b/src/category-budgets/category-budgets.service.ts
@@ -1,4 +1,12 @@
 import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { CategoryBudget } from './entity';
+import { Repository } from 'typeorm';
 
 @Injectable()
-export class CategoryBudgetsService {}
+export class CategoryBudgetsService {
+	constructor(
+		@InjectRepository(CategoryBudget)
+		private readonly categoryBudgetsRepository: Repository<CategoryBudget>, //
+	) {}
+}

--- a/src/category-budgets/entity/category-budget.entity.ts
+++ b/src/category-budgets/entity/category-budget.entity.ts
@@ -1,0 +1,18 @@
+import { Budget } from 'src/budgets';
+import { Category } from 'src/categories';
+import { BaseEntity } from 'src/global';
+import { Column, Entity, JoinColumn, ManyToOne } from 'typeorm';
+
+@Entity()
+export class CategoryBudget extends BaseEntity {
+	@Column({ default: 0 })
+	amount: number;
+
+	@ManyToOne(() => Category, { nullable: false })
+	@JoinColumn({ name: 'category_id' })
+	category: Category;
+
+	@ManyToOne(() => Budget, { nullable: false })
+	@JoinColumn({ name: 'budget_id' })
+	budget: Budget;
+}

--- a/src/category-budgets/entity/index.ts
+++ b/src/category-budgets/entity/index.ts
@@ -1,0 +1,1 @@
+export * from './category-budget.entity';

--- a/src/category-budgets/index.ts
+++ b/src/category-budgets/index.ts
@@ -1,1 +1,3 @@
 export * from './category-budgets.module';
+export * from './category-budgets.service';
+export * from './entity';

--- a/src/category-budgets/index.ts
+++ b/src/category-budgets/index.ts
@@ -1,0 +1,1 @@
+export * from './category-budgets.module';

--- a/test/category-budgets/category-budgets.service.spec.ts
+++ b/test/category-budgets/category-budgets.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { CategoryBudgetsService } from '../../src/category-budgets/category-budgets.service';
+
+describe('CategoryBudgetsService', () => {
+	let service: CategoryBudgetsService;
+
+	beforeEach(async () => {
+		const module: TestingModule = await Test.createTestingModule({
+			providers: [CategoryBudgetsService],
+		}).compile();
+
+		service = module.get<CategoryBudgetsService>(CategoryBudgetsService);
+	});
+
+	it('should be defined', () => {
+		expect(service).toBeDefined();
+	});
+});


### PR DESCRIPTION
- 카테고리별 예산 모듈 생성
- 카테고리별 예산 엔티티 생성
  - amount 칼럼 int 타입, default 0 설정
  - Category 엔티티와 ManyToOne 관계 설정
  - Budget 엔티티와 ManyToOne 관계 설정

#24 