### PR TITLE
feat: 예산 설정 API

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -3,5 +3,5 @@
 	"trailingComma": "all",
 	"useTabs": true,
 	"tabWidth": 4,
-	"printWidth": 100
+	"printWidth": 120
 }

--- a/src/budgets/budgets.controller.ts
+++ b/src/budgets/budgets.controller.ts
@@ -1,9 +1,24 @@
-import { Controller } from '@nestjs/common';
+import { Body, Controller, Put, UseGuards } from '@nestjs/common';
 import { BudgetsService } from './budgets.service';
+import { SetBudgetDto } from './dto';
+import { AccessTokenGuard } from 'src/auth';
+import { GetUser, ResponseMessage } from 'src/global';
+import { User } from 'src/users';
+import { BudgetResponse } from './enums';
 
 @Controller('budgets')
+@UseGuards(AccessTokenGuard)
 export class BudgetsController {
 	constructor(
 		private readonly budgetsService: BudgetsService, //
 	) {}
+
+	@Put()
+	@ResponseMessage(BudgetResponse.SET_BUDGET)
+	async setBudget(
+		@Body() setBudgetDto: SetBudgetDto, //
+		@GetUser() user: User,
+	) {
+		return await this.budgetsService.setBudget(setBudgetDto, user);
+	}
 }

--- a/src/budgets/budgets.module.ts
+++ b/src/budgets/budgets.module.ts
@@ -3,9 +3,10 @@ import { BudgetsController } from './budgets.controller';
 import { BudgetsService } from './budgets.service';
 import { MonthlyBudgetsModule } from 'src/monthly-budgets';
 import { CategoryBudgetsModule } from 'src/category-budgets';
+import { CategoriesModule } from 'src/categories';
 
 @Module({
-	imports: [MonthlyBudgetsModule, CategoryBudgetsModule],
+	imports: [MonthlyBudgetsModule, CategoryBudgetsModule, CategoriesModule],
 	controllers: [BudgetsController],
 	providers: [BudgetsService],
 })

--- a/src/budgets/budgets.service.ts
+++ b/src/budgets/budgets.service.ts
@@ -1,11 +1,98 @@
 import { Injectable } from '@nestjs/common';
 import { CategoryBudgetsService } from 'src/category-budgets';
-import { MonthlyBudgetsService } from 'src/monthly-budgets';
+import { MonthlyBudget, MonthlyBudgetsService } from 'src/monthly-budgets';
+import { SetBudgetDto } from './dto';
+import { CategoriesAmount, getDate, getLowercaseCategoryNameEnumKey, getTotalAmount } from 'src/global';
+import { User } from 'src/users';
+import { CategoriesService } from 'src/categories';
 
 @Injectable()
 export class BudgetsService {
 	constructor(
 		private readonly monthlyBudgetsService: MonthlyBudgetsService,
 		private readonly categoryBudgetsService: CategoryBudgetsService,
+		private readonly categoriesService: CategoriesService,
 	) {}
+
+	async setBudget(setBudgetDto: SetBudgetDto, user: User) {
+		const { yyyyMM, ...categoriesAmount } = setBudgetDto;
+		const { year, month } = getDate(yyyyMM);
+		const totalAmount = getTotalAmount(categoriesAmount);
+
+		const oldMonthlyBudget = await this.monthlyBudgetsService.findOne({
+			year,
+			month,
+			user: {
+				id: user.id,
+			},
+		});
+		// 월별 예산이 이미 존재하는 경우 월별 예산과 카테고리별 예산 업데이트
+		if (oldMonthlyBudget) {
+			return await this.updateBudgets(oldMonthlyBudget, categoriesAmount, totalAmount);
+		}
+		// 월별 예산이 존재하지 않는 경우 월별 예산과 카테고리별 예산 생성 후 저장
+		else {
+			return await this.saveNewBudgets(year, month, totalAmount, user, categoriesAmount);
+		}
+	}
+
+	async updateBudgets(
+		monthlyBudget: MonthlyBudget, //
+		categoriesAmount: CategoriesAmount,
+		totalAmount: number,
+	) {
+		// 월별 예산 전체 금액이 변경된 경우에만 월별 예산 업데이트
+		if (monthlyBudget.totalAmount !== totalAmount) {
+			monthlyBudget.totalAmount = totalAmount;
+			await this.monthlyBudgetsService.saveOne(monthlyBudget);
+		}
+		const oldCategoryBudgets = await this.categoryBudgetsService.findMany({
+			monthlyBudget: {
+				id: monthlyBudget.id,
+			},
+		});
+		oldCategoryBudgets.forEach((categoryBudget) => {
+			const categoryName = getLowercaseCategoryNameEnumKey(categoryBudget.category.name);
+			if (categoriesAmount[categoryName] !== categoryBudget.amount) {
+				categoryBudget.amount = categoriesAmount[categoryName];
+				return;
+			}
+		});
+		const categoryBudgets = await this.categoryBudgetsService.saveMany(oldCategoryBudgets);
+
+		return {
+			monthlyBudget,
+			categoryBudgets,
+		};
+	}
+
+	async saveNewBudgets(
+		year: number,
+		month: number,
+		totalAmount: number,
+		user: User,
+		categoriesAmount: CategoriesAmount,
+	) {
+		const createdMonthlyBudget = this.monthlyBudgetsService.createOne({ year, month, totalAmount, user });
+		const monthlyBudget = await this.monthlyBudgetsService.saveOne(createdMonthlyBudget);
+		const categories = await this.categoriesService.findAll();
+		const createdCategoryBudgets = [];
+		categories.forEach((category) => {
+			const categoryName = getLowercaseCategoryNameEnumKey(category.name);
+			// 카테고리별 예산 생성
+			createdCategoryBudgets.push(
+				this.categoryBudgetsService.createOne({
+					amount: categoriesAmount[categoryName],
+					category,
+					monthlyBudget,
+				}),
+			);
+		});
+		const categoryBudgets = await this.categoryBudgetsService.saveMany(createdCategoryBudgets);
+
+		return {
+			monthlyBudget,
+			categoryBudgets,
+		};
+	}
 }

--- a/src/budgets/dto/index.ts
+++ b/src/budgets/dto/index.ts
@@ -1,0 +1,1 @@
+export * from './set-budget.dto';

--- a/src/budgets/dto/set-budget.dto.ts
+++ b/src/budgets/dto/set-budget.dto.ts
@@ -1,0 +1,30 @@
+import { IsValidAmount, IsValidYYYYMMFormat } from 'src/global';
+
+export class SetBudgetDto {
+	@IsValidYYYYMMFormat()
+	yyyyMM: string;
+
+	@IsValidAmount()
+	food: number;
+
+	@IsValidAmount()
+	cafe: number;
+
+	@IsValidAmount()
+	transport: number;
+
+	@IsValidAmount()
+	living: number;
+
+	@IsValidAmount()
+	shop: number;
+
+	@IsValidAmount()
+	hobby: number;
+
+	@IsValidAmount()
+	health: number;
+
+	@IsValidAmount()
+	culture: number;
+}

--- a/src/budgets/enums/budget-response.enum.ts
+++ b/src/budgets/enums/budget-response.enum.ts
@@ -1,0 +1,3 @@
+export enum BudgetResponse {
+	SET_BUDGET = '예산 설정 성공',
+}

--- a/src/budgets/enums/index.ts
+++ b/src/budgets/enums/index.ts
@@ -1,0 +1,1 @@
+export * from './budget-response.enum';

--- a/src/categories/categories.module.ts
+++ b/src/categories/categories.module.ts
@@ -8,5 +8,6 @@ import { Category } from './entity';
 	imports: [TypeOrmModule.forFeature([Category])],
 	controllers: [CategoriesController],
 	providers: [CategoriesService],
+	exports: [CategoriesService],
 })
 export class CategoriesModule {}

--- a/src/category-budgets/category-budgets.service.ts
+++ b/src/category-budgets/category-budgets.service.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { CategoryBudget } from './entity';
-import { Repository } from 'typeorm';
+import { FindOptionsWhere, Repository } from 'typeorm';
 
 @Injectable()
 export class CategoryBudgetsService {
@@ -9,4 +9,21 @@ export class CategoryBudgetsService {
 		@InjectRepository(CategoryBudget)
 		private readonly categoryBudgetsRepository: Repository<CategoryBudget>, //
 	) {}
+
+	async findMany(where: FindOptionsWhere<CategoryBudget>): Promise<CategoryBudget[]> {
+		return await this.categoryBudgetsRepository.find({
+			where,
+			relations: {
+				category: true,
+			},
+		});
+	}
+
+	createOne({ amount, category, monthlyBudget }: Partial<CategoryBudget>): CategoryBudget {
+		return this.categoryBudgetsRepository.create({ amount, category, monthlyBudget });
+	}
+
+	async saveMany(categoryBudgets: CategoryBudget[]): Promise<CategoryBudget[]> {
+		return await this.categoryBudgetsRepository.save(categoryBudgets);
+	}
 }

--- a/src/global/decorators/index.ts
+++ b/src/global/decorators/index.ts
@@ -1,2 +1,4 @@
 export * from './get-user.decorator';
 export * from './response-key.decorator';
+export * from './is-valid-amount.decorator';
+export * from './is-valid-yyyy-mm-format.decorator';

--- a/src/global/decorators/is-valid-amount.decorator.ts
+++ b/src/global/decorators/is-valid-amount.decorator.ts
@@ -1,0 +1,10 @@
+import { applyDecorators } from '@nestjs/common';
+import { IsInt, IsNotEmpty, Min } from 'class-validator';
+
+export function IsValidAmount() {
+	return applyDecorators(
+		IsNotEmpty({ message: '$property 필드는 필수 입력 필드입니다.' }),
+		IsInt({ message: '$property 필드에 정수를 입력해야 합니다.' }),
+		Min(0, { message: '$property 필드에 0 이상의 정수를 입력해야 합니다.' }),
+	);
+}

--- a/src/global/decorators/is-valid-yyyy-mm-format.decorator.ts
+++ b/src/global/decorators/is-valid-yyyy-mm-format.decorator.ts
@@ -1,0 +1,33 @@
+import { applyDecorators } from '@nestjs/common';
+import { Expose } from 'class-transformer';
+import { IsNotEmpty, ValidationOptions, registerDecorator } from 'class-validator';
+
+export function IsOnlyYYYYMM(validationOptions?: ValidationOptions) {
+	return function (object: Record<string, any>, propertyName: string) {
+		registerDecorator({
+			name: 'isOnlyYYYYMM',
+			target: object.constructor,
+			propertyName: propertyName,
+			constraints: [],
+			options: {
+				message: 'yyyy_mm 필드에 2020-12 형식의 년도와 월을 입력해야 합니다.',
+				...validationOptions,
+			},
+			validator: {
+				validate(value: any) {
+					const regex = /^\d{4}(-)(((0)[0-9])|((1)[0-2]))$/;
+					// return typeof value === 'string' && regex.test(value);
+					return typeof value === 'string' && regex.test(value);
+				},
+			},
+		});
+	};
+}
+
+export function IsValidYYYYMMFormat() {
+	return applyDecorators(
+		Expose({ name: 'yyyy_mm' }),
+		IsNotEmpty({ message: 'yyyy_mm 필드는 필수 입력 필드입니다.' }),
+		IsOnlyYYYYMM(),
+	);
+}

--- a/src/global/index.ts
+++ b/src/global/index.ts
@@ -6,3 +6,4 @@ export * from './interceptors';
 export * from './interfaces';
 export * from './enums';
 export * from './utils';
+export * from './types';

--- a/src/global/index.ts
+++ b/src/global/index.ts
@@ -5,3 +5,4 @@ export * from './filters';
 export * from './interceptors';
 export * from './interfaces';
 export * from './enums';
+export * from './utils';

--- a/src/global/interfaces/index.ts
+++ b/src/global/interfaces/index.ts
@@ -1,1 +1,2 @@
 export * from './token.payload';
+export * from './year-month-day';

--- a/src/global/interfaces/year-month-day.ts
+++ b/src/global/interfaces/year-month-day.ts
@@ -1,0 +1,5 @@
+export interface YearMonthDay {
+	year: number;
+	month: number;
+	day: number;
+}

--- a/src/global/types/categories-amount.ts
+++ b/src/global/types/categories-amount.ts
@@ -1,0 +1,7 @@
+import { CategoryName } from '../enums';
+
+type LowercaseCategoryNameKeys = Lowercase<keyof typeof CategoryName>;
+
+export type CategoriesAmount = {
+	[key in LowercaseCategoryNameKeys]: number;
+};

--- a/src/global/types/index.ts
+++ b/src/global/types/index.ts
@@ -1,0 +1,1 @@
+export * from './categories-amount';

--- a/src/global/utils/get-date.ts
+++ b/src/global/utils/get-date.ts
@@ -1,0 +1,13 @@
+import { YearMonthDay } from '../interfaces';
+
+export function getDate(yyyyMM: string): YearMonthDay {
+	const date = new Date(yyyyMM);
+	const year = date.getFullYear();
+	const month = date.getMonth() + 1;
+	const day = date.getDate();
+	return {
+		year,
+		month,
+		day,
+	};
+}

--- a/src/global/utils/get-lowercase-category-name-enum-key.ts
+++ b/src/global/utils/get-lowercase-category-name-enum-key.ts
@@ -1,0 +1,10 @@
+import { CategoryName } from '../enums';
+
+export function getLowercaseCategoryNameEnumKey(categoryName: string): string {
+	const categoryNameValues = Object.values(CategoryName);
+	const categoryNameKeys = Object.keys(CategoryName);
+	const index = categoryNameValues.indexOf(
+		categoryName as unknown as CategoryName, //
+	);
+	return categoryNameKeys[index].toLowerCase();
+}

--- a/src/global/utils/get-total-amount.ts
+++ b/src/global/utils/get-total-amount.ts
@@ -1,0 +1,14 @@
+import { CategoryName } from '../enums';
+
+type LowercaseCategoryNameKeys = Lowercase<keyof typeof CategoryName>;
+type CategoriesAmount = {
+	[key in LowercaseCategoryNameKeys]: number;
+};
+
+export function getTotalAmount(categoriesAmount: CategoriesAmount): number {
+	let totalAmount = 0;
+	for (const key in categoriesAmount) {
+		totalAmount += categoriesAmount[key];
+	}
+	return totalAmount;
+}

--- a/src/global/utils/get-total-amount.ts
+++ b/src/global/utils/get-total-amount.ts
@@ -1,9 +1,4 @@
-import { CategoryName } from '../enums';
-
-type LowercaseCategoryNameKeys = Lowercase<keyof typeof CategoryName>;
-type CategoriesAmount = {
-	[key in LowercaseCategoryNameKeys]: number;
-};
+import { CategoriesAmount } from '../types';
 
 export function getTotalAmount(categoriesAmount: CategoriesAmount): number {
 	let totalAmount = 0;

--- a/src/global/utils/index.ts
+++ b/src/global/utils/index.ts
@@ -1,2 +1,3 @@
 export * from './get-date';
 export * from './get-total-amount';
+export * from './get-lowercase-category-name-enum-key';

--- a/src/global/utils/index.ts
+++ b/src/global/utils/index.ts
@@ -1,0 +1,2 @@
+export * from './get-date';
+export * from './get-total-amount';

--- a/src/monthly-budgets/monthly-budgets.service.ts
+++ b/src/monthly-budgets/monthly-budgets.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository } from 'typeorm';
+import { FindOptionsWhere, Repository } from 'typeorm';
 import { MonthlyBudget } from './entity';
 
 @Injectable()
@@ -9,4 +9,16 @@ export class MonthlyBudgetsService {
 		@InjectRepository(MonthlyBudget)
 		private readonly monthlyBudgetsRepository: Repository<MonthlyBudget>, //
 	) {}
+
+	async findOne(where: FindOptionsWhere<MonthlyBudget>): Promise<MonthlyBudget> {
+		return await this.monthlyBudgetsRepository.findOne({ where });
+	}
+
+	createOne({ year, month, totalAmount, user }: Partial<MonthlyBudget>): MonthlyBudget {
+		return this.monthlyBudgetsRepository.create({ year, month, totalAmount, user });
+	}
+
+	async saveOne(monthlyBudget: MonthlyBudget): Promise<MonthlyBudget> {
+		return await this.monthlyBudgetsRepository.save(monthlyBudget);
+	}
 }


### PR DESCRIPTION
feat: 예산 설정 API
    
- PUT /budgets
- 예산 컨트롤러 액세스 토큰 가드 적용
- setBudget 라우트 핸들러 추가
  - setBudget 서비스 로직이 반환한 월별 예산, 카테고리별 예산 응답
- setBudget 서비스 로직 추가
  - 월별 예산이 존재하는 경우 월별 예산과 카테고리별 예산 업데이트
  - 월별 예산이 존재하지 않는 경우 월별 예산과 카테고리별 예산 생성 후 저장

#26 