### PR TITLE
feat: 카테고리별 지출 엔티티

### DIFF
--- a/src/category-expenses/category-expenses.module.ts
+++ b/src/category-expenses/category-expenses.module.ts
@@ -1,7 +1,10 @@
 import { Module } from '@nestjs/common';
 import { CategoryExpensesService } from './category-expenses.service';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { CategoryExpense } from './entity';
 
 @Module({
+	imports: [TypeOrmModule.forFeature([CategoryExpense])],
 	providers: [CategoryExpensesService],
 	exports: [CategoryExpensesService],
 })

--- a/src/category-expenses/category-expenses.service.ts
+++ b/src/category-expenses/category-expenses.service.ts
@@ -1,4 +1,12 @@
 import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { CategoryExpense } from './entity';
+import { Repository } from 'typeorm';
 
 @Injectable()
-export class CategoryExpensesService {}
+export class CategoryExpensesService {
+	constructor(
+		@InjectRepository(CategoryExpense)
+		private readonly categoryExpensesRepository: Repository<CategoryExpense>, //
+	) {}
+}

--- a/src/category-expenses/entity/category-expense.entity.ts
+++ b/src/category-expenses/entity/category-expense.entity.ts
@@ -1,0 +1,28 @@
+import { Category } from 'src/categories';
+import { BaseEntity } from 'src/global';
+import { MonthlyBudget } from 'src/monthly-budgets';
+import { MonthlyExpense } from 'src/monthly-expenses';
+import { Column, Entity, JoinColumn, ManyToOne } from 'typeorm';
+
+@Entity()
+export class CategoryExpense extends BaseEntity {
+	@Column({ type: 'smallint' })
+	date: number;
+
+	@Column()
+	memo: string;
+
+	@Column({ default: 0 })
+	amount: number;
+
+	@Column()
+	excludingInTotal: boolean;
+
+	@ManyToOne(() => MonthlyBudget, { nullable: false })
+	@JoinColumn()
+	monthlyExpense: MonthlyExpense;
+
+	@ManyToOne(() => Category, { nullable: false })
+	@JoinColumn()
+	category: Category;
+}

--- a/src/category-expenses/entity/index.ts
+++ b/src/category-expenses/entity/index.ts
@@ -1,0 +1,1 @@
+export * from './category-expense.entity';

--- a/src/category-expenses/index.ts
+++ b/src/category-expenses/index.ts
@@ -1,2 +1,3 @@
 export * from './category-expenses.module';
 export * from './category-expenses.service';
+export * from './entity';


### PR DESCRIPTION
- 카테고리별 지출 엔티티 생성
  - date 칼럼 smallint 타입 설정
  - memo 칼럼 varchar 타입 설정
  - amount 칼럼 int 타입 설정, 기본값 0 설정
  - excluding_in_total 칼럼 boolean 타입 설정
  - 월별 지출 엔티티와 ManyToOne 관계 설정
  - 카테고리 엔티티와 ManyToOne 관계 설정
- 카테고리별 지출 서비스에 카테고리별 지출 엔티티 레포지토리 의존성 주입

feat-#35