### PR TITLE
feat: 지출 기록 생성 API

### DIFF
--- a/src/categories/categories.service.ts
+++ b/src/categories/categories.service.ts
@@ -1,7 +1,7 @@
 import { Injectable, OnModuleInit } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Category } from './entity';
-import { Repository } from 'typeorm';
+import { FindOptionsWhere, Repository } from 'typeorm';
 import { CategoryName } from 'src/global';
 
 @Injectable()
@@ -23,5 +23,9 @@ export class CategoriesService implements OnModuleInit {
 
 	async findAll(): Promise<Category[]> {
 		return await this.categoriesRepository.find();
+	}
+
+	async findOne(where: FindOptionsWhere<Category>): Promise<Category> {
+		return await this.categoriesRepository.findOne({ where });
 	}
 }

--- a/src/category-expenses/category-expenses.service.ts
+++ b/src/category-expenses/category-expenses.service.ts
@@ -9,4 +9,26 @@ export class CategoryExpensesService {
 		@InjectRepository(CategoryExpense)
 		private readonly categoryExpensesRepository: Repository<CategoryExpense>, //
 	) {}
+
+	createOne({
+		date,
+		memo,
+		amount,
+		excludingInTotal,
+		monthlyExpense,
+		category,
+	}: Partial<CategoryExpense>): CategoryExpense {
+		return this.categoryExpensesRepository.create({
+			date,
+			memo,
+			amount,
+			excludingInTotal,
+			monthlyExpense,
+			category,
+		});
+	}
+
+	async saveOne(categoryExpense: CategoryExpense): Promise<CategoryExpense> {
+		return await this.categoryExpensesRepository.save(categoryExpense);
+	}
 }

--- a/src/category-expenses/entity/category-expense.entity.ts
+++ b/src/category-expenses/entity/category-expense.entity.ts
@@ -1,6 +1,5 @@
 import { Category } from 'src/categories';
 import { BaseEntity } from 'src/global';
-import { MonthlyBudget } from 'src/monthly-budgets';
 import { MonthlyExpense } from 'src/monthly-expenses';
 import { Column, Entity, JoinColumn, ManyToOne } from 'typeorm';
 
@@ -18,11 +17,11 @@ export class CategoryExpense extends BaseEntity {
 	@Column()
 	excludingInTotal: boolean;
 
-	@ManyToOne(() => MonthlyBudget, { nullable: false })
-	@JoinColumn()
+	@ManyToOne(() => MonthlyExpense, { nullable: false })
+	@JoinColumn({ name: 'monthly_expense_id' })
 	monthlyExpense: MonthlyExpense;
 
 	@ManyToOne(() => Category, { nullable: false })
-	@JoinColumn()
+	@JoinColumn({ name: 'category_id' })
 	category: Category;
 }

--- a/src/expenses/classes/index.ts
+++ b/src/expenses/classes/index.ts
@@ -1,0 +1,1 @@
+export * from './is-valid-category-string.class';

--- a/src/expenses/classes/is-valid-category-string.class.ts
+++ b/src/expenses/classes/is-valid-category-string.class.ts
@@ -1,0 +1,15 @@
+import { ValidatorConstraint, ValidatorConstraintInterface } from 'class-validator';
+import { CategoryName, getLowercaseCategoryNameEnumKey } from 'src/global';
+
+@ValidatorConstraint({ name: 'valid-category-string', async: false })
+export class IsValidCategoryString implements ValidatorConstraintInterface {
+	validate(value: any): boolean {
+		// CreateExpenseDto의 category 필드의 값으로부터 CategoryName enum 키를 가져올 수 없으면 유효하지 않은 값으로 판단
+		const categoryEnumKey = getLowercaseCategoryNameEnumKey(value);
+		return categoryEnumKey !== undefined;
+	}
+
+	defaultMessage(): string {
+		return `$property 필드에 입력할 수 있는 값은 ${Object.values(CategoryName)}입니다.`;
+	}
+}

--- a/src/expenses/dto/create-expense.dto.ts
+++ b/src/expenses/dto/create-expense.dto.ts
@@ -1,0 +1,25 @@
+import { IsBoolean, IsNotEmpty, IsString, Validate } from 'class-validator';
+import { IsValidAmount, IsValidYYYYMMDDFormat } from 'src/global';
+import { IsValidCategoryString } from '../classes';
+import { Transform } from 'class-transformer';
+
+export class CreateExpenseDto {
+	@IsValidYYYYMMDDFormat()
+	yyyyMMDD: string;
+
+	@IsNotEmpty({ message: '$property 필드는 필수 입력 필드입니다.' })
+	@Validate(IsValidCategoryString)
+	category: string;
+
+	@IsValidAmount()
+	amount: number;
+
+	@IsNotEmpty({ message: '$property 필드는 필수 입력 필드입니다.' })
+	@IsString({ message: '$property 필드에 문자열을 입력해야 합니다.' })
+	memo: string;
+
+	@IsNotEmpty({ message: '$property 필드는 필수 입력 필드입니다.' })
+	@IsBoolean({ message: '$property 필드에 불리언 값을 입력해야 합니다.' })
+	@Transform(({ value }) => value === true)
+	exclude: boolean;
+}

--- a/src/expenses/dto/index.ts
+++ b/src/expenses/dto/index.ts
@@ -1,0 +1,1 @@
+export * from './create-expense.dto';

--- a/src/expenses/enums/expense-response.enum.ts
+++ b/src/expenses/enums/expense-response.enum.ts
@@ -1,0 +1,3 @@
+export enum ExpenseResponse {
+	CREATE_EXPENSE = '지출 기록 생성 성공',
+}

--- a/src/expenses/enums/index.ts
+++ b/src/expenses/enums/index.ts
@@ -1,0 +1,1 @@
+export * from './expense-response.enum';

--- a/src/expenses/expenses.controller.ts
+++ b/src/expenses/expenses.controller.ts
@@ -1,4 +1,24 @@
-import { Controller } from '@nestjs/common';
+import { Body, Controller, Post, UseGuards } from '@nestjs/common';
+import { ExpensesService } from './expenses.service';
+import { CreateExpenseDto } from './dto';
+import { GetUser, ResponseMessage } from 'src/global';
+import { User } from 'src/users';
+import { ExpenseResponse } from './enums';
+import { AccessTokenGuard } from 'src/auth';
 
 @Controller('expenses')
-export class ExpensesController {}
+@UseGuards(AccessTokenGuard)
+export class ExpensesController {
+	constructor(
+		private readonly expensesService: ExpensesService, //
+	) {}
+
+	@Post()
+	@ResponseMessage(ExpenseResponse.CREATE_EXPENSE)
+	async createExpense(
+		@Body() createExpenseDto: CreateExpenseDto, //
+		@GetUser() user: User,
+	) {
+		return await this.expensesService.createExpense(createExpenseDto, user);
+	}
+}

--- a/src/expenses/expenses.module.ts
+++ b/src/expenses/expenses.module.ts
@@ -3,9 +3,10 @@ import { ExpensesController } from './expenses.controller';
 import { ExpensesService } from './expenses.service';
 import { MonthlyExpensesModule } from 'src/monthly-expenses';
 import { CategoryExpensesModule } from 'src/category-expenses';
+import { CategoriesModule } from 'src/categories';
 
 @Module({
-	imports: [MonthlyExpensesModule, CategoryExpensesModule],
+	imports: [MonthlyExpensesModule, CategoryExpensesModule, CategoriesModule],
 	controllers: [ExpensesController],
 	providers: [ExpensesService],
 })

--- a/src/expenses/expenses.service.ts
+++ b/src/expenses/expenses.service.ts
@@ -1,11 +1,108 @@
 import { Injectable } from '@nestjs/common';
-import { CategoryExpensesService } from 'src/category-expenses';
-import { MonthlyExpensesService } from 'src/monthly-expenses';
+import { CategoryExpense, CategoryExpensesService } from 'src/category-expenses';
+import { MonthlyExpense, MonthlyExpensesService } from 'src/monthly-expenses';
+import { CreateExpenseDto } from './dto';
+import { User } from 'src/users';
+import { YearMonthDay, getDate } from 'src/global';
+import { CategoriesService } from 'src/categories';
 
 @Injectable()
 export class ExpensesService {
 	constructor(
 		private readonly monthlyExpensesService: MonthlyExpensesService,
 		private readonly categoryExpensesService: CategoryExpensesService,
+		private readonly categoriesService: CategoriesService, //
 	) {}
+
+	async createExpense(createExpenseDto: CreateExpenseDto, user: User) {
+		const { yyyyMMDD, category, amount, memo, exclude } = createExpenseDto;
+		const { year, month, day } = getDate(yyyyMMDD);
+
+		const oldMonthlyExpense = await this.monthlyExpensesService.findOne({ year, month, user: { id: user.id } });
+		// 월별 지출이 존재하는 경우 월별 지출 전체 금액 업데이트, 카테고리별 지출 생성 후 저장
+		if (oldMonthlyExpense) {
+			const monthlyBudget = await this.updateMonthlyExpenseTotalAmount(oldMonthlyExpense, { amount });
+			const categoryExpense = await this.saveNewCategoryExpense({ day }, monthlyBudget, {
+				amount,
+				category,
+				memo,
+				exclude,
+			});
+			return {
+				monthlyBudget,
+				categoryExpense,
+			};
+		}
+		// 월별 지출이 존재하지 않는 경우 월별 지출, 카테고리별 지출 생성 후 저장
+		else {
+			const monthlyExpense = await this.saveNewMonthlyExpense({ year, month }, { amount }, user);
+			const categoryExpense = await this.saveNewCategoryExpense({ day }, monthlyExpense, {
+				amount,
+				category,
+				memo,
+				exclude,
+			});
+
+			return {
+				monthlyExpense,
+				categoryExpense,
+			};
+		}
+	}
+
+	// 월별 지출 전체 금액 업데이트
+	async updateMonthlyExpenseTotalAmount(
+		oldMonthlyExpense: MonthlyExpense,
+		partialDto: Partial<Omit<CreateExpenseDto, 'yyyyMMDD'>>,
+	) {
+		const { amount } = partialDto;
+
+		// 월별 지출 전체 금액 업데이트
+		oldMonthlyExpense.totalAmount += amount;
+		const monthlyExpense = await this.monthlyExpensesService.saveOne(oldMonthlyExpense);
+
+		return monthlyExpense;
+	}
+
+	// 새로운 월별 지출 생성 후 저장
+	async saveNewMonthlyExpense(
+		yearMonthDay: Omit<YearMonthDay, 'day'>,
+		partialDto: Partial<Omit<CreateExpenseDto, 'yyyyMMDD'>>,
+		user: User,
+	) {
+		const { year, month } = yearMonthDay;
+		const { amount: totalAmount } = partialDto;
+
+		// 월별 지출 생성 후 저장
+		const createdMonthlyExpense = this.monthlyExpensesService.createOne({ year, month, totalAmount, user });
+		const monthlyExpense = await this.monthlyExpensesService.saveOne(createdMonthlyExpense);
+
+		return monthlyExpense;
+	}
+
+	// 새로운 카테고리별 지출 생성 후 저장
+	async saveNewCategoryExpense(
+		yearMonthDay: Pick<YearMonthDay, 'day'>,
+		monthlyExpense: MonthlyExpense,
+		partialDto: Partial<Omit<CreateExpenseDto, 'yyyyMMDD'>>,
+	): Promise<CategoryExpense> {
+		const { day: date } = yearMonthDay;
+		const { amount, category: name, memo, exclude: excludingInTotal } = partialDto;
+
+		// 카테고리 조회
+		const category = await this.categoriesService.findOne({ name });
+
+		// 카테고리별 지출 생성 후 저장
+		const createdCategoryExpense = this.categoryExpensesService.createOne({
+			date,
+			memo,
+			amount,
+			excludingInTotal,
+			monthlyExpense,
+			category,
+		});
+		const categoryExpense = await this.categoryExpensesService.saveOne(createdCategoryExpense);
+
+		return categoryExpense;
+	}
 }

--- a/src/global/decorators/index.ts
+++ b/src/global/decorators/index.ts
@@ -2,3 +2,4 @@ export * from './get-user.decorator';
 export * from './response-key.decorator';
 export * from './is-valid-amount.decorator';
 export * from './is-valid-yyyy-mm-format.decorator';
+export * from './is-valid-yyyy-mm-dd-format.decorator';

--- a/src/global/decorators/is-valid-yyyy-mm-dd-format.decorator.ts
+++ b/src/global/decorators/is-valid-yyyy-mm-dd-format.decorator.ts
@@ -1,0 +1,32 @@
+import { applyDecorators } from '@nestjs/common';
+import { Expose } from 'class-transformer';
+import { IsNotEmpty, ValidationOptions, registerDecorator } from 'class-validator';
+
+export function IsOnlyYYYYMMDD(validationOptions?: ValidationOptions) {
+	return function (object: Record<string, any>, propertyName: string) {
+		registerDecorator({
+			name: 'isOnlyYYYYMMDD',
+			target: object.constructor,
+			propertyName: propertyName,
+			constraints: [],
+			options: {
+				message: 'yyyy_mm_dd 필드에 2020-12-30 형식의 년도, 월, 일을 입력해야 합니다.',
+				...validationOptions,
+			},
+			validator: {
+				validate(value: any) {
+					const regex = /^\d{4}(-)(((0)[0-9])|((1)[0-2]))(-)([0-2][0-9]|(3)[0-1])$/;
+					return typeof value === 'string' && regex.test(value);
+				},
+			},
+		});
+	};
+}
+
+export function IsValidYYYYMMDDFormat() {
+	return applyDecorators(
+		Expose({ name: 'yyyy_mm_dd' }),
+		IsNotEmpty({ message: 'yyyy_mm_dd 필드는 필수 입력 필드입니다.' }),
+		IsOnlyYYYYMMDD(),
+	);
+}

--- a/src/global/utils/get-lowercase-category-name-enum-key.ts
+++ b/src/global/utils/get-lowercase-category-name-enum-key.ts
@@ -6,5 +6,5 @@ export function getLowercaseCategoryNameEnumKey(categoryName: string): string {
 	const index = categoryNameValues.indexOf(
 		categoryName as unknown as CategoryName, //
 	);
-	return categoryNameKeys[index].toLowerCase();
+	return categoryNameKeys[index]?.toLowerCase();
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -15,9 +15,6 @@ async function bootstrap() {
 		new ValidationPipe({
 			transform: true,
 			whitelist: true,
-			transformOptions: {
-				enableImplicitConversion: true,
-			},
 		}),
 	);
 

--- a/src/monthly-expenses/monthly-expenses.service.ts
+++ b/src/monthly-expenses/monthly-expenses.service.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { MonthlyExpense } from './entity';
-import { Repository } from 'typeorm';
+import { FindOptionsWhere, Repository } from 'typeorm';
 
 @Injectable()
 export class MonthlyExpensesService {
@@ -9,4 +9,16 @@ export class MonthlyExpensesService {
 		@InjectRepository(MonthlyExpense)
 		private readonly monthlyExpensesRepository: Repository<MonthlyExpense>, //
 	) {}
+
+	async findOne(where: FindOptionsWhere<MonthlyExpense>): Promise<MonthlyExpense> {
+		return await this.monthlyExpensesRepository.findOne({ where });
+	}
+
+	createOne({ year, month, totalAmount, user }: Partial<MonthlyExpense>): MonthlyExpense {
+		return this.monthlyExpensesRepository.create({ year, month, totalAmount, user });
+	}
+
+	async saveOne(monthlyExpense: MonthlyExpense): Promise<MonthlyExpense> {
+		return await this.monthlyExpensesRepository.save(monthlyExpense);
+	}
 }


### PR DESCRIPTION
feat: 지출 기록 생성 API
    
- POST /expenses
- 지출 컨트롤러 액세스 토큰 가드 적용
- createExpense 라우트 핸들러 추가
  - createExpense 서비스 로직이 반환한 월별 지출, 카테고리별 지출 응답
- createExpense 서비스 로직 추가
  - 월별 지출이 존재하는 경우 월별 지출 전체 금액 업데이트, 카테고리별 지출 생성 후 저장
  - 월별 지출이 존재하지 않는 경우 월별 지출과 카테고리별 지출 생성 후 저장

feat-#36