### PR TITLE
feat: 지출 기록 삭제 API

### DIFF
--- a/src/category-expenses/category-expenses.service.ts
+++ b/src/category-expenses/category-expenses.service.ts
@@ -47,4 +47,8 @@ export class CategoryExpensesService {
 	async updateOne(id: string, partialCategoryExpense: QueryPartialEntity<CategoryExpense>) {
 		await this.categoryExpensesRepository.update({ id }, partialCategoryExpense);
 	}
+
+	async softDeleteOne(where: FindOptionsWhere<CategoryExpense>) {
+		await this.categoryExpensesRepository.softDelete(where);
+	}
 }

--- a/src/expenses/enums/expense-exception.enum.ts
+++ b/src/expenses/enums/expense-exception.enum.ts
@@ -3,4 +3,5 @@ export enum ExpenseException {
 	NOT_FOUND = '존재하지 않는 지출입니다.',
 	CANNOT_UPDATE_OTHERS = '자신의 지출 기록만 수정할 수 있습니다.',
 	INVALID_YEAR_MONTH = '유효하지 않은 년도 또는 월입니다.',
+	CANNOT_DELETE_OTHERS = '자신의 지출 기록만 삭제할 수 있습니다.',
 }

--- a/src/expenses/enums/expense-response.enum.ts
+++ b/src/expenses/enums/expense-response.enum.ts
@@ -1,4 +1,5 @@
 export enum ExpenseResponse {
 	CREATE_EXPENSE = '지출 기록 생성 성공',
 	UPDATE_EXPENSE = '지출 기록 수정 성공',
+	DELETE_EXPENSE = '지출 기록 삭제 성공',
 }

--- a/src/expenses/expenses.controller.ts
+++ b/src/expenses/expenses.controller.ts
@@ -1,4 +1,4 @@
-import { Body, Controller, Param, Patch, Post, UseGuards } from '@nestjs/common';
+import { Body, Controller, Delete, Param, Patch, Post, UseGuards } from '@nestjs/common';
 import { ExpensesService } from './expenses.service';
 import { CreateExpenseDto, UpdateExpenseDto } from './dto';
 import { GetUser, ResponseMessage } from 'src/global';
@@ -31,5 +31,14 @@ export class ExpensesController {
 		@GetUser() user: User,
 	) {
 		return await this.expensesService.updateExpense(id, updateExpenseDto, user);
+	}
+
+	@Delete(':id')
+	@ResponseMessage(ExpenseResponse.DELETE_EXPENSE)
+	async deleteExpense(
+		@Param('id', InvalidParseUUIDPipe) id: string, //
+		@GetUser() user: User,
+	) {
+		return await this.expensesService.deleteExpense(id, user);
 	}
 }


### PR DESCRIPTION
- DELETE /expenses/:id
- deleteExpense 라우트 핸들러 추가
  - deleteExpense 서비스 로직을 호출
- deleteExpense 서비스 로직
  - id에 해당하는 카테고리별 지출을 찾지 못하면 NotFound 예외를 던짐
  - 요청한 유저의 지출이 아니라면 Unauthorized 예외를 던짐
  - id에 해당하는 카테고리별 지출 soft 삭제
  - 삭제한 카테고리별 지출 금액만큼 월별 지출 금액 차감

feat-#42