### PR TITLE
feat: 지출 기록 상세 조회 API

### DIFF
--- a/src/expenses/enums/expense-exception.enum.ts
+++ b/src/expenses/enums/expense-exception.enum.ts
@@ -4,4 +4,5 @@ export enum ExpenseException {
 	CANNOT_UPDATE_OTHERS = '자신의 지출 기록만 수정할 수 있습니다.',
 	INVALID_YEAR_MONTH = '유효하지 않은 년도 또는 월입니다.',
 	CANNOT_DELETE_OTHERS = '자신의 지출 기록만 삭제할 수 있습니다.',
+	CANNT_GET_OTHERS = '자신의 지출 기록만 조회할 수 있습니다.',
 }

--- a/src/expenses/enums/expense-response.enum.ts
+++ b/src/expenses/enums/expense-response.enum.ts
@@ -2,4 +2,5 @@ export enum ExpenseResponse {
 	CREATE_EXPENSE = '지출 기록 생성 성공',
 	UPDATE_EXPENSE = '지출 기록 수정 성공',
 	DELETE_EXPENSE = '지출 기록 삭제 성공',
+	GET_EXPENSE = '지출 기록 상세 조회 성공',
 }

--- a/src/expenses/expenses.controller.ts
+++ b/src/expenses/expenses.controller.ts
@@ -1,4 +1,4 @@
-import { Body, Controller, Delete, Param, Patch, Post, UseGuards } from '@nestjs/common';
+import { Body, Controller, Delete, Get, Param, Patch, Post, UseGuards } from '@nestjs/common';
 import { ExpensesService } from './expenses.service';
 import { CreateExpenseDto, UpdateExpenseDto } from './dto';
 import { GetUser, ResponseMessage } from 'src/global';
@@ -40,5 +40,14 @@ export class ExpensesController {
 		@GetUser() user: User,
 	) {
 		return await this.expensesService.deleteExpense(id, user);
+	}
+
+	@Get(':id')
+	@ResponseMessage(ExpenseResponse.GET_EXPENSE)
+	async getExpense(
+		@Param('id', InvalidParseUUIDPipe) id: string, //
+		@GetUser() user: User,
+	) {
+		return await this.expensesService.getExpense(id, user);
 	}
 }

--- a/src/expenses/expenses.service.ts
+++ b/src/expenses/expenses.service.ts
@@ -215,4 +215,21 @@ export class ExpensesService {
 		categoryExpense.monthlyExpense.totalAmount -= categoryExpense.amount;
 		await this.monthlyExpensesService.saveOne(categoryExpense.monthlyExpense);
 	}
+
+	async getExpense(id: string, user: User) {
+		const categoryExpense = await this.categoryExpensesService.findOne(
+			{ id },
+			{ monthlyExpense: { user: true }, category: true },
+		);
+		if (!categoryExpense) {
+			throw new NotFoundException(ExpenseException.NOT_FOUND);
+		}
+
+		const userIdMatched = categoryExpense.monthlyExpense.user.id === user.id;
+		if (!userIdMatched) {
+			throw new UnauthorizedException(ExpenseException.CANNT_GET_OTHERS);
+		}
+
+		return categoryExpense;
+	}
 }


### PR DESCRIPTION
- GET /expenses/:id
- getExpense 라우트 핸들러 추가
  - getExpense 서비스 로직이 반환한 카테고리별 지출 응답
- getExpense 서비스 로직 추가
  - id에 해당하는 카테고리별 지출을 찾지 못하면 NotFound 예외를 던짐
  - 요청한 유저의 지출이 아니라면 Unauthorizaed 예외를 던짐
  - 카테고리별 지출 응답(월별 지출, 카테고리 정보 포함)

feat-#44