### PR TITLE
feat: 지출 기록 목록 조회 API

### DIFF
--- a/src/expenses/dto/create-expense.dto.ts
+++ b/src/expenses/dto/create-expense.dto.ts
@@ -4,7 +4,7 @@ import { IsValidCategoryString } from '../classes';
 import { Transform } from 'class-transformer';
 
 export class CreateExpenseDto {
-	@IsValidYYYYMMDDFormat()
+	@IsValidYYYYMMDDFormat('yyyy_mm_dd')
 	yyyyMMDD: string;
 
 	@IsNotEmpty({ message: '$property 필드는 필수 입력 필드입니다.' })

--- a/src/expenses/dto/create-expense.dto.ts
+++ b/src/expenses/dto/create-expense.dto.ts
@@ -11,7 +11,7 @@ export class CreateExpenseDto {
 	@Validate(IsValidCategoryString)
 	category: string;
 
-	@IsValidAmount()
+	@IsValidAmount('amount')
 	amount: number;
 
 	@IsNotEmpty({ message: '$property 필드는 필수 입력 필드입니다.' })

--- a/src/expenses/dto/get-expenses-query.dto.ts
+++ b/src/expenses/dto/get-expenses-query.dto.ts
@@ -1,0 +1,24 @@
+import { IsValidAmount, IsValidYYYYMMDDFormat } from 'src/global';
+import { IsValidCategoryString } from '../classes';
+import { IsOptional, Validate } from 'class-validator';
+import { Type } from 'class-transformer';
+
+export class GetExpensesQueryDto {
+	@IsValidYYYYMMDDFormat('start_date')
+	startDate: string;
+
+	@IsValidYYYYMMDDFormat('end_date')
+	endDate: string;
+
+	@IsOptional()
+	@Validate(IsValidCategoryString)
+	category: string;
+
+	@IsValidAmount('min_amount', false)
+	@Type(() => Number)
+	minAmount: number;
+
+	@IsValidAmount('max_amount', false)
+	@Type(() => Number)
+	maxAmount: number;
+}

--- a/src/expenses/dto/index.ts
+++ b/src/expenses/dto/index.ts
@@ -1,2 +1,3 @@
 export * from './create-expense.dto';
 export * from './update-expense.dto';
+export * from './get-expenses-query.dto';

--- a/src/expenses/enums/expense-response.enum.ts
+++ b/src/expenses/enums/expense-response.enum.ts
@@ -3,4 +3,5 @@ export enum ExpenseResponse {
 	UPDATE_EXPENSE = '지출 기록 수정 성공',
 	DELETE_EXPENSE = '지출 기록 삭제 성공',
 	GET_EXPENSE = '지출 기록 상세 조회 성공',
+	GET_EXPENSES = '지출 기록 목록 조회 성공',
 }

--- a/src/expenses/expenses.controller.ts
+++ b/src/expenses/expenses.controller.ts
@@ -1,6 +1,6 @@
-import { Body, Controller, Delete, Get, Param, Patch, Post, UseGuards } from '@nestjs/common';
+import { Body, Controller, Delete, Get, Param, Patch, Post, Query, UseGuards } from '@nestjs/common';
 import { ExpensesService } from './expenses.service';
-import { CreateExpenseDto, UpdateExpenseDto } from './dto';
+import { CreateExpenseDto, GetExpensesQueryDto, UpdateExpenseDto } from './dto';
 import { GetUser, ResponseMessage } from 'src/global';
 import { User } from 'src/users';
 import { ExpenseResponse } from './enums';
@@ -40,6 +40,15 @@ export class ExpensesController {
 		@GetUser() user: User,
 	) {
 		return await this.expensesService.deleteExpense(id, user);
+	}
+
+	@Get()
+	@ResponseMessage(ExpenseResponse.GET_EXPENSES)
+	async getExpenses(
+		@Query() getExpensesQueryDto: GetExpensesQueryDto, //
+		@GetUser() user: User,
+	) {
+		return await this.expensesService.getExpenses(getExpensesQueryDto, user);
 	}
 
 	@Get(':id')

--- a/src/expenses/expenses.service.ts
+++ b/src/expenses/expenses.service.ts
@@ -1,7 +1,7 @@
 import { BadRequestException, Injectable, NotFoundException, UnauthorizedException } from '@nestjs/common';
 import { CategoryExpense, CategoryExpensesService } from 'src/category-expenses';
 import { MonthlyExpense, MonthlyExpensesService } from 'src/monthly-expenses';
-import { CreateExpenseDto, UpdateExpenseDto } from './dto';
+import { CreateExpenseDto, GetExpensesQueryDto, UpdateExpenseDto } from './dto';
 import { User } from 'src/users';
 import { YearMonthDay, getDate } from 'src/global';
 import { CategoriesService } from 'src/categories';
@@ -231,5 +231,185 @@ export class ExpensesService {
 		}
 
 		return categoryExpense;
+	}
+
+	async getExpenses(getExpensesQueryDto: GetExpensesQueryDto, user: User) {
+		const { startDate, endDate, category, minAmount, maxAmount } = getExpensesQueryDto;
+		const { year: startYear, month: startMonth, day: startDay } = getDate(startDate);
+		const { year: endYear, month: endMonth, day: endDay } = getDate(endDate);
+
+		// 시작 년도와 종료 년도, 시작 월과 종료 월 사이에 존재하는 월별 지출 조회
+		const monthlyExpenses = await this.monthlyExpensesService.findMonthlyExpenses(
+			{ year: startYear, month: startMonth },
+			{ year: endYear, month: endMonth },
+			{ category, minAmount, maxAmount },
+			user,
+		);
+
+		// 시작 일과 종료 일 범위 바깥에 있는 카테고리별 지출 필터링
+		monthlyExpenses.forEach(
+			this.filterOutsideDateRange2({ month: startMonth, day: startDay }, { month: endMonth, day: endDay }),
+		);
+
+		// 월별 지출 합계 계산
+		const monthlySums = new Map<string, number>(); // 조회 기간 동안의 월별 지출 합계 { '2023-11': 11월 지출 금액, '2023-12': 12월 지출 금액, ... }
+		monthlyExpenses.forEach(this.caculateMonthlySums2(monthlySums));
+
+		// 각 카테고리별 지출의 합계 계산
+		const categorySums = new Map<string, number>(); // 조회 기간 동안의 각 카테고리별 지출 합계 { '음식': 200000, '교통': 200000, ... }
+		monthlyExpenses.forEach(this.calculateCategorySums2(categorySums));
+
+		// 지출 기록, 월별 지출 합계, 각 카테고리별 지출 합계 리턴
+		return {
+			expenses: monthlyExpenses,
+			sums: {
+				months: monthlySums,
+				category: categorySums,
+			},
+		};
+	}
+
+	filterOutsideDateRange(
+		monthlyExpenses: MonthlyExpense[],
+		startDate: Omit<YearMonthDay, 'year'>,
+		endDate: Omit<YearMonthDay, 'year'>,
+	) {
+		const { month: startMonth, day: startDay } = startDate;
+		const { month: endMonth, day: endDay } = endDate;
+
+		// 시작 날짜와 종료 날짜 사이에 존재하는 카테고리별 지출만 월별 지출에 할당
+		monthlyExpenses.forEach((monthlyExpense) => {
+			const equalToStartMonth = monthlyExpense.month === startMonth;
+			const equalToEndMonth = monthlyExpense.month === endMonth;
+
+			const categoryExpensesBetweenDates = monthlyExpense.categoryExpenses.filter((categoryExpense) => {
+				// 시작 월의 경우 startDay보다 작은 날짜는 필터링
+				const beforeStartDay = categoryExpense.date < startDay;
+				if (equalToStartMonth && beforeStartDay) {
+					return false;
+				}
+
+				// 종료 월의 경우 endDay보다 큰 날짜는 필터링
+				const afterEndDay = categoryExpense.date > endDay;
+				if (equalToEndMonth && afterEndDay) {
+					return false;
+				}
+
+				return true;
+			});
+
+			monthlyExpense.categoryExpenses = categoryExpensesBetweenDates;
+		});
+	}
+
+	filterOutsideDateRange2(startDate: Omit<YearMonthDay, 'year'>, endDate: Omit<YearMonthDay, 'year'>) {
+		const { month: startMonth, day: startDay } = startDate;
+		const { month: endMonth, day: endDay } = endDate;
+
+		return (monthlyExpense: MonthlyExpense) => {
+			const equalToStartMonth = monthlyExpense.month === startMonth;
+			const equalToEndMonth = monthlyExpense.month === endMonth;
+
+			const categoryExpensesBetweenDates = monthlyExpense.categoryExpenses.filter((categoryExpense) => {
+				// 시작 월의 경우 startDay보다 작은 날짜는 필터링
+				const beforeStartDay = categoryExpense.date < startDay;
+				if (equalToStartMonth && beforeStartDay) {
+					return false;
+				}
+
+				// 종료 월의 경우 endDay보다 큰 날짜는 필터링
+				const afterEndDay = categoryExpense.date > endDay;
+				if (equalToEndMonth && afterEndDay) {
+					return false;
+				}
+
+				return true;
+			});
+
+			monthlyExpense.categoryExpenses = categoryExpensesBetweenDates;
+		};
+	}
+
+	calculateMonthlySums(monthlyExpenses: MonthlyExpense[], monthlySums: Map<string, number>) {
+		monthlyExpenses.forEach((monthlyExpense) => {
+			// 응답에서 월별 지출 전체 금액 제거
+			delete monthlyExpense.totalAmount;
+
+			// 월별 지출 합계 키: 'yyyy-mm'
+			const yearMonth = `${monthlyExpense.year}-${monthlyExpense.month}`;
+
+			// 월별 지출 합계 계산
+			monthlyExpense.categoryExpenses.forEach((categoryExpense) => {
+				let monthlySum = monthlySums.get(yearMonth) ?? 0;
+
+				// 지출 합계제외 여부가 true이면 합계 계산 시 제외
+				if (!categoryExpense.excludingInTotal) {
+					monthlySum += categoryExpense.amount;
+				}
+
+				monthlySums.set(yearMonth, monthlySum);
+			});
+		});
+	}
+
+	caculateMonthlySums2(monthlySums: Map<string, number>) {
+		return (monthlyExpense: MonthlyExpense) => {
+			// 응답에서 월별 지출 전체 금액 제거
+			delete monthlyExpense.totalAmount;
+
+			// 월별 지출 합계 키: 'yyyy-mm'
+			const yearMonth = `${monthlyExpense.year}-${monthlyExpense.month}`;
+
+			// 월별 지출 합계 계산
+			monthlyExpense.categoryExpenses.forEach((categoryExpense) => {
+				let monthlySum = monthlySums.get(yearMonth) ?? 0;
+
+				// 지출 합계제외 여부가 true이면 합계 계산 시 제외
+				if (!categoryExpense.excludingInTotal) {
+					monthlySum += categoryExpense.amount;
+				}
+
+				monthlySums.set(yearMonth, monthlySum);
+			});
+		};
+	}
+
+	calculateCategorySums(monthlyExpenses: MonthlyExpense[], categorySums: Map<string, number>) {
+		// 카테고리별 지출 합계 계산
+		monthlyExpenses.forEach((monthlyExpense) => {
+			monthlyExpense.categoryExpenses.forEach((categoryExpense) => {
+				// 카테고리별 지출 합계 키: 카테고리 이름
+				const categoryName = categoryExpense.category.name;
+				let categorySum = categorySums.get(categoryName) ?? 0;
+
+				// 지출 합계제외 여부가 true이면 합계 계산 시 제외
+				if (!categoryExpense.excludingInTotal) {
+					categorySum += categoryExpense.amount;
+				}
+
+				if (categorySum !== 0) {
+					categorySums.set(categoryName, categorySum);
+				}
+			});
+		});
+	}
+
+	calculateCategorySums2(categorySums: Map<string, number>) {
+		return (monthlyExpense: MonthlyExpense) => {
+			monthlyExpense.categoryExpenses.forEach((categoryExpense) => {
+				// 카테고리별 지출 합계 키: 카테고리 이름
+				const categoryName = categoryExpense.category.name;
+				let categorySum = categorySums.get(categoryName) ?? 0;
+
+				// 지출 합계제외 여부가 true이면 합계 계산 시 제외
+				if (!categoryExpense.excludingInTotal) {
+					categorySum += categoryExpense.amount;
+				}
+
+				if (categorySum !== 0) {
+					categorySums.set(categoryName, categorySum);
+				}
+			});
+		};
 	}
 }

--- a/src/expenses/index.ts
+++ b/src/expenses/index.ts
@@ -1,1 +1,2 @@
 export * from './expenses.module';
+export * from './dto';

--- a/src/global/decorators/is-valid-amount.decorator.ts
+++ b/src/global/decorators/is-valid-amount.decorator.ts
@@ -1,10 +1,10 @@
 import { applyDecorators } from '@nestjs/common';
-import { IsInt, IsNotEmpty, Min } from 'class-validator';
+import { IsInt, IsNotEmpty, IsOptional, Min } from 'class-validator';
 
-export function IsValidAmount() {
+export function IsValidAmount(exposePropertyName = '$property', isNotEmpty = true) {
 	return applyDecorators(
-		IsNotEmpty({ message: '$property 필드는 필수 입력 필드입니다.' }),
-		IsInt({ message: '$property 필드에 정수를 입력해야 합니다.' }),
-		Min(0, { message: '$property 필드에 0 이상의 정수를 입력해야 합니다.' }),
+		isNotEmpty ? IsNotEmpty({ message: `${exposePropertyName} 필드는 필수 입력 필드입니다.` }) : IsOptional(),
+		IsInt({ message: `${exposePropertyName} 필드에 정수를 입력해야 합니다.` }),
+		Min(0, { message: `${exposePropertyName} 필드에 0 이상의 정수를 입력해야 합니다.` }),
 	);
 }

--- a/src/global/decorators/is-valid-amount.decorator.ts
+++ b/src/global/decorators/is-valid-amount.decorator.ts
@@ -1,8 +1,10 @@
 import { applyDecorators } from '@nestjs/common';
+import { Expose } from 'class-transformer';
 import { IsInt, IsNotEmpty, IsOptional, Min } from 'class-validator';
 
 export function IsValidAmount(exposePropertyName = '$property', isNotEmpty = true) {
 	return applyDecorators(
+		Expose({ name: exposePropertyName }),
 		isNotEmpty ? IsNotEmpty({ message: `${exposePropertyName} 필드는 필수 입력 필드입니다.` }) : IsOptional(),
 		IsInt({ message: `${exposePropertyName} 필드에 정수를 입력해야 합니다.` }),
 		Min(0, { message: `${exposePropertyName} 필드에 0 이상의 정수를 입력해야 합니다.` }),

--- a/src/global/decorators/is-valid-yyyy-mm-dd-format.decorator.ts
+++ b/src/global/decorators/is-valid-yyyy-mm-dd-format.decorator.ts
@@ -10,7 +10,6 @@ export function IsOnlyYYYYMMDD(validationOptions?: ValidationOptions) {
 			propertyName: propertyName,
 			constraints: [],
 			options: {
-				message: 'yyyy_mm_dd 필드에 2020-12-30 형식의 년도, 월, 일을 입력해야 합니다.',
 				...validationOptions,
 			},
 			validator: {
@@ -23,10 +22,10 @@ export function IsOnlyYYYYMMDD(validationOptions?: ValidationOptions) {
 	};
 }
 
-export function IsValidYYYYMMDDFormat() {
+export function IsValidYYYYMMDDFormat(exposePropertyName: string) {
 	return applyDecorators(
-		Expose({ name: 'yyyy_mm_dd' }),
-		IsNotEmpty({ message: 'yyyy_mm_dd 필드는 필수 입력 필드입니다.' }),
-		IsOnlyYYYYMMDD(),
+		Expose({ name: exposePropertyName }),
+		IsNotEmpty({ message: `${exposePropertyName} 필드는 필수 입력 필드입니다.` }),
+		IsOnlyYYYYMMDD({ message: `${exposePropertyName} 필드에 2020-12-30 형식의 년도, 월, 일을 입력해야 합니다.` }),
 	);
 }

--- a/src/monthly-expenses/entity/monthly-expense.entity.ts
+++ b/src/monthly-expenses/entity/monthly-expense.entity.ts
@@ -1,6 +1,7 @@
+import { CategoryExpense } from 'src/category-expenses';
 import { BaseEntity } from 'src/global';
 import { User } from 'src/users';
-import { Column, Entity, JoinColumn, ManyToOne } from 'typeorm';
+import { Column, Entity, JoinColumn, ManyToOne, OneToMany } from 'typeorm';
 
 @Entity()
 export class MonthlyExpense extends BaseEntity {
@@ -16,4 +17,7 @@ export class MonthlyExpense extends BaseEntity {
 	@ManyToOne(() => User, { nullable: false })
 	@JoinColumn({ name: 'user_id' })
 	user: User;
+
+	@OneToMany(() => CategoryExpense, (categoryExpense) => categoryExpense.monthlyExpense)
+	categoryExpenses: CategoryExpense[];
 }

--- a/src/monthly-expenses/monthly-expenses.service.ts
+++ b/src/monthly-expenses/monthly-expenses.service.ts
@@ -2,6 +2,9 @@ import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { MonthlyExpense } from './entity';
 import { FindOptionsRelations, FindOptionsWhere, Repository } from 'typeorm';
+import { GetExpensesQueryDto } from 'src/expenses';
+import { User } from 'src/users';
+import { YearMonthDay } from 'src/global';
 
 @Injectable()
 export class MonthlyExpensesService {
@@ -27,5 +30,40 @@ export class MonthlyExpensesService {
 
 	async saveOne(monthlyExpense: MonthlyExpense): Promise<MonthlyExpense> {
 		return await this.monthlyExpensesRepository.save(monthlyExpense);
+	}
+
+	async findMonthlyExpenses(
+		startDate: Omit<YearMonthDay, 'day'>,
+		endDate: Omit<YearMonthDay, 'day'>,
+		partialDto: Partial<GetExpensesQueryDto>,
+		user: User,
+	) {
+		const { year: startYear, month: startMonth } = startDate;
+		const { year: endYear, month: endMonth } = endDate;
+		const { category, minAmount, maxAmount } = partialDto;
+
+		const qb = this.monthlyExpensesRepository.createQueryBuilder('monthly_expense');
+
+		// 요청한 유저의 조회 기간(시작 날짜와 종료 날짜 사이)의 월별 지출과 카테고리별 지출 조회
+		qb.leftJoinAndSelect('monthly_expense.categoryExpenses', 'category_expense')
+			.leftJoinAndSelect('category_expense.category', 'category')
+			.where('monthly_expense.user = :userId', { userId: user.id })
+			.andWhere('monthly_expense.year BETWEEN :startYear AND :endYear', { startYear, endYear }) //
+			.andWhere('monthly_expense.month BETWEEN :startMonth AND :endMonth', { startMonth, endMonth });
+
+		// 카테고리로 조회하는 경우 카테고리 조건 추가
+		if (category) {
+			qb.andWhere('category.name = :category', { category });
+		}
+
+		// 최소 금액과 최대 금액으로 조회하는 경우 금액 범위 조건 추가
+		if (minAmount) {
+			qb.andWhere('category_expense.amount >= :minAmount', { minAmount });
+		}
+		if (maxAmount) {
+			qb.andWhere('category_expense.amount <= :maxAmount', { maxAmount });
+		}
+
+		return await qb.getMany();
 	}
 }


### PR DESCRIPTION
- GET /expenses
- getExpenses 라우트 핸들러 추가
  - getExpenses 서비스 로직이 반환한 지출 기록 목록과 월별 지출 합계, 카테고리별 지출 합계 응답
- getExpenses 서비스 로직 추가
  - 요청한 유저의 지출 기록 중 시작 날짜와 종료 날짜 사이의 지출 기록 목록 조회
  - 월별 지출 합계와 카테고리별 지출 합계를 계산
  - 지출 기록 목록, 월별 지출 합계, 카테고리별 지출 합계 리턴

feat-#46