### PR TITLE
feat: GetExpensesQueryDtoPipe 지출 기록 목록 조회 dto 파이프

### DIFF
--- a/src/expenses/enums/expense-exception.enum.ts
+++ b/src/expenses/enums/expense-exception.enum.ts
@@ -5,4 +5,6 @@ export enum ExpenseException {
 	INVALID_YEAR_MONTH = '유효하지 않은 년도 또는 월입니다.',
 	CANNOT_DELETE_OTHERS = '자신의 지출 기록만 삭제할 수 있습니다.',
 	CANNT_GET_OTHERS = '자신의 지출 기록만 조회할 수 있습니다.',
+	INVALID_START_DATE = '시작 날짜가 종료 날짜보다 클 수 없습니다.',
+	INVALID_MIN_AMOUNT = '최소 금액이 최대 금액보다 클 수 없습니다.',
 }

--- a/src/expenses/expenses.controller.ts
+++ b/src/expenses/expenses.controller.ts
@@ -6,6 +6,7 @@ import { User } from 'src/users';
 import { ExpenseResponse } from './enums';
 import { AccessTokenGuard } from 'src/auth';
 import { InvalidParseUUIDPipe } from './pipes';
+import { GetExpensesQueryDtoPipe } from './pipes/get-expenses-query-dto.pipe';
 
 @Controller('expenses')
 @UseGuards(AccessTokenGuard)
@@ -45,7 +46,7 @@ export class ExpensesController {
 	@Get()
 	@ResponseMessage(ExpenseResponse.GET_EXPENSES)
 	async getExpenses(
-		@Query() getExpensesQueryDto: GetExpensesQueryDto, //
+		@Query(GetExpensesQueryDtoPipe) getExpensesQueryDto: GetExpensesQueryDto, //
 		@GetUser() user: User,
 	) {
 		return await this.expensesService.getExpenses(getExpensesQueryDto, user);

--- a/src/expenses/pipes/get-expenses-query-dto.pipe.ts
+++ b/src/expenses/pipes/get-expenses-query-dto.pipe.ts
@@ -1,0 +1,30 @@
+import { BadRequestException, Injectable, PipeTransform } from '@nestjs/common';
+import { GetExpensesQueryDto } from '../dto';
+import { ExpenseException } from '../enums';
+
+@Injectable()
+export class GetExpensesQueryDtoPipe implements PipeTransform {
+	transform(dto: GetExpensesQueryDto) {
+		const { startDate, endDate, minAmount, maxAmount } = dto;
+
+		const isBefore = this.isStartDateBeforeEndDate(startDate, endDate);
+		if (!isBefore) {
+			throw new BadRequestException(ExpenseException.INVALID_START_DATE);
+		}
+
+		if (minAmount && maxAmount) {
+			if (minAmount > maxAmount) {
+				throw new BadRequestException(ExpenseException.INVALID_MIN_AMOUNT);
+			}
+		}
+
+		return dto;
+	}
+
+	isStartDateBeforeEndDate(startDate: string, endDate: string): boolean {
+		const startTime = new Date(startDate).getTime();
+		const endTime = new Date(endDate).getTime();
+
+		return startTime <= endTime;
+	}
+}

--- a/src/expenses/pipes/index.ts
+++ b/src/expenses/pipes/index.ts
@@ -1,1 +1,2 @@
 export * from './invalid-parse-uuid-pipe';
+export * from './get-expenses-query-dto.pipe';


### PR DESCRIPTION
- dto의 startDate가 endDate보다 작은지 검증
  - startDate가 endDate보다 큰 경우 BadRequest 예외를 던짐
- dto의 minAmount가 maxAmount보다 작은지 검증
  - minAmount가 maxAmount보다 큰 경우 BadRequest 예외를 던짐

feat-#48