### PR TITLE
feat: 오늘 지출 안내 API

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
 		"build": "nest build",
 		"format": "prettier --write \"src/**/*.ts\" \"test/**/*.ts\"",
 		"start": "nest start",
-		"start:dev": "TZ=Asia/Seoul NODE_ENV=development nest start --watch",
+		"start:dev": "NODE_ENV=development nest start --watch",
 		"start:debug": "nest start --debug --watch",
 		"start:prod": "node dist/main",
 		"lint": "eslint \"{src,apps,libs,test}/**/*.ts\" --fix",

--- a/src/budgets/dto/set-budget.dto.ts
+++ b/src/budgets/dto/set-budget.dto.ts
@@ -4,27 +4,27 @@ export class SetBudgetDto {
 	@IsValidYYYYMMFormat()
 	yyyyMM: string;
 
-	@IsValidAmount()
+	@IsValidAmount('food')
 	food: number;
 
-	@IsValidAmount()
+	@IsValidAmount('cafe')
 	cafe: number;
 
-	@IsValidAmount()
+	@IsValidAmount('transport')
 	transport: number;
 
-	@IsValidAmount()
+	@IsValidAmount('living')
 	living: number;
 
-	@IsValidAmount()
+	@IsValidAmount('shop')
 	shop: number;
 
-	@IsValidAmount()
+	@IsValidAmount('hobby')
 	hobby: number;
 
-	@IsValidAmount()
+	@IsValidAmount('health')
 	health: number;
 
-	@IsValidAmount()
+	@IsValidAmount('culture')
 	culture: number;
 }

--- a/src/expenses/enums/expense-exception.enum.ts
+++ b/src/expenses/enums/expense-exception.enum.ts
@@ -7,4 +7,6 @@ export enum ExpenseException {
 	CANNOT_GET_OTHERS = '자신의 지출 기록만 조회할 수 있습니다.',
 	INVALID_START_DATE = '시작 날짜가 종료 날짜보다 클 수 없습니다.',
 	INVALID_MIN_AMOUNT = '최소 금액이 최대 금액보다 클 수 없습니다.',
+	BUDGET_NOT_FOUND = '예산이 존재하지 않습니다.',
+	CANNOT_MAKE_TODAY_SUMMARY = '오늘 지출 안내 내용을 생성할 수 없습니다.',
 }

--- a/src/expenses/enums/expense-exception.enum.ts
+++ b/src/expenses/enums/expense-exception.enum.ts
@@ -1,10 +1,10 @@
 export enum ExpenseException {
 	INVALID_ID = '잘못된 id 형식입니다.',
-	NOT_FOUND = '존재하지 않는 지출입니다.',
+	NOT_FOUND = '지출이 존재하지 않습니다.',
 	CANNOT_UPDATE_OTHERS = '자신의 지출 기록만 수정할 수 있습니다.',
 	INVALID_YEAR_MONTH = '유효하지 않은 년도 또는 월입니다.',
 	CANNOT_DELETE_OTHERS = '자신의 지출 기록만 삭제할 수 있습니다.',
-	CANNT_GET_OTHERS = '자신의 지출 기록만 조회할 수 있습니다.',
+	CANNOT_GET_OTHERS = '자신의 지출 기록만 조회할 수 있습니다.',
 	INVALID_START_DATE = '시작 날짜가 종료 날짜보다 클 수 없습니다.',
 	INVALID_MIN_AMOUNT = '최소 금액이 최대 금액보다 클 수 없습니다.',
 }

--- a/src/expenses/enums/expense-response.enum.ts
+++ b/src/expenses/enums/expense-response.enum.ts
@@ -4,4 +4,5 @@ export enum ExpenseResponse {
 	DELETE_EXPENSE = '지출 기록 삭제 성공',
 	GET_EXPENSE = '지출 기록 상세 조회 성공',
 	GET_EXPENSES = '지출 기록 목록 조회 성공',
+	GET_TODAY_EXPENSES_SUMMARY = '오늘 지출 안내 성공',
 }

--- a/src/expenses/expenses.controller.ts
+++ b/src/expenses/expenses.controller.ts
@@ -52,6 +52,14 @@ export class ExpensesController {
 		return await this.expensesService.getExpenses(getExpensesQueryDto, user);
 	}
 
+	@Get('consult/summary')
+	@ResponseMessage(ExpenseResponse.GET_TODAY_EXPENSES_SUMMARY)
+	async getTodayExpensesSummary(
+		@GetUser() user: User, //
+	) {
+		return await this.expensesService.getTodayExpensesSummary(user);
+	}
+
 	@Get(':id')
 	@ResponseMessage(ExpenseResponse.GET_EXPENSE)
 	async getExpense(

--- a/src/expenses/expenses.module.ts
+++ b/src/expenses/expenses.module.ts
@@ -4,9 +4,10 @@ import { ExpensesService } from './expenses.service';
 import { MonthlyExpensesModule } from 'src/monthly-expenses';
 import { CategoryExpensesModule } from 'src/category-expenses';
 import { CategoriesModule } from 'src/categories';
+import { MonthlyBudgetsModule } from 'src/monthly-budgets';
 
 @Module({
-	imports: [MonthlyExpensesModule, CategoryExpensesModule, CategoriesModule],
+	imports: [MonthlyExpensesModule, CategoryExpensesModule, CategoriesModule, MonthlyBudgetsModule],
 	controllers: [ExpensesController],
 	providers: [ExpensesService],
 })

--- a/src/global/utils/get-today.ts
+++ b/src/global/utils/get-today.ts
@@ -1,0 +1,9 @@
+import { YearMonthDay } from '../interfaces';
+import { getDate } from './get-date';
+
+export function getToday(): YearMonthDay {
+	const now = new Date();
+	const krTimeDiff = 9 * 60 * 60 * 1000; // 9시간을 밀리초로 표현
+	const today = new Date(now.getTime() + krTimeDiff);
+	return getDate(today.toISOString());
+}

--- a/src/global/utils/index.ts
+++ b/src/global/utils/index.ts
@@ -1,3 +1,4 @@
 export * from './get-date';
 export * from './get-total-amount';
 export * from './get-lowercase-category-name-enum-key';
+export * from './get-today';

--- a/src/monthly-budgets/entity/monthly-budget.entity.ts
+++ b/src/monthly-budgets/entity/monthly-budget.entity.ts
@@ -1,6 +1,7 @@
+import { CategoryBudget } from 'src/category-budgets';
 import { BaseEntity } from 'src/global';
 import { User } from 'src/users';
-import { Column, Entity, JoinColumn, ManyToOne } from 'typeorm';
+import { Column, Entity, JoinColumn, ManyToOne, OneToMany } from 'typeorm';
 
 @Entity()
 export class MonthlyBudget extends BaseEntity {
@@ -16,4 +17,7 @@ export class MonthlyBudget extends BaseEntity {
 	@ManyToOne(() => User)
 	@JoinColumn({ name: 'user_id' })
 	user: User;
+
+	@OneToMany(() => CategoryBudget, (categoryBudget) => categoryBudget.monthlyBudget)
+	categoryBudgets: CategoryBudget[];
 }

--- a/src/monthly-budgets/monthly-budgets.service.ts
+++ b/src/monthly-budgets/monthly-budgets.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { FindOptionsWhere, Repository } from 'typeorm';
+import { FindOptionsRelations, FindOptionsWhere, Repository } from 'typeorm';
 import { MonthlyBudget } from './entity';
 
 @Injectable()
@@ -10,8 +10,11 @@ export class MonthlyBudgetsService {
 		private readonly monthlyBudgetsRepository: Repository<MonthlyBudget>, //
 	) {}
 
-	async findOne(where: FindOptionsWhere<MonthlyBudget>): Promise<MonthlyBudget> {
-		return await this.monthlyBudgetsRepository.findOne({ where });
+	async findOne(
+		where: FindOptionsWhere<MonthlyBudget>,
+		relations?: FindOptionsRelations<MonthlyBudget>,
+	): Promise<MonthlyBudget> {
+		return await this.monthlyBudgetsRepository.findOne({ where, relations });
 	}
 
 	createOne({ year, month, totalAmount, user }: Partial<MonthlyBudget>): MonthlyBudget {


### PR DESCRIPTION
- GET /expenses/consult/summary
- getTodayExpensesSummary 라우트 핸들러 추가
  - getTodayExpensesSummary 서비스 로직이 반환한 오늘 전체 지출 요약, 카테고리별 지출 요약 응답
- getTodayExpensesSummary 서비스 로직
  - 오늘 기준 월별 예산이 존재하지 않으면 UnprocessableEntity 예외를 던짐
  - 오늘 기준 월별 지출이 존재하지 않으면(지출이 없음) UnprocessableEntity 예외를 던짐
  - 오늘 기준 전체 지출 금액 합계, 적정 지출 금액, 위험도 계산
  - 오늘 기준 카테고리별 지출 금액 합계, 적정 지출 금액, 위험도 계산

feat-#50