### PR TITLE
fix: dataSource 파일 DataSourceOptions

### DIFF
--- a/dataSource.ts
+++ b/dataSource.ts
@@ -1,28 +1,26 @@
-import { ConfigService } from '@nestjs/config';
 import { config } from 'dotenv';
 import { DataSource, DataSourceOptions } from 'typeorm';
 import { SeederOptions } from 'typeorm-extension';
-import { BaseEntity } from 'src/global';
 import { User } from 'src/users';
 import { MonthlyBudgetsFactory, MainSeeder, UsersFactory, CategoryBudgetsFactory } from 'src/database';
 import { MonthlyBudget } from 'src/monthly-budgets';
 import { CategoryBudget } from 'src/category-budgets';
 import { Category } from 'src/categories';
+import { SnakeNamingStrategy } from 'typeorm-naming-strategies';
 
 config({
 	path: '.development.env',
 });
-const configService = new ConfigService();
 
 const options: DataSourceOptions & SeederOptions = {
 	type: 'postgres',
 	host: 'localhost',
-	port: configService.getOrThrow<number>('POSTGRESQL_PORT'),
-	username: configService.getOrThrow('POSTGRESQL_USER'),
-	password: configService.getOrThrow('POSTGRESQL_PASSWORD'),
-	database: configService.getOrThrow('POSTGRESQL_DATABASE'),
-	synchronize: configService.getOrThrow<boolean>('POSTGRESQL_SYNCHRONIZE'),
-	entities: [BaseEntity, User, MonthlyBudget, CategoryBudget, Category],
+	port: Number(process.env.POSTGRESQL_PORT),
+	username: process.env.POSTGRESQL_USER,
+	password: process.env.POSTGRESQL_PASSWORD,
+	database: process.env.POSTGRESQL_DATABASE,
+	entities: [User, MonthlyBudget, CategoryBudget, Category],
+	namingStrategy: new SnakeNamingStrategy(),
 	factories: [UsersFactory, MonthlyBudgetsFactory, CategoryBudgetsFactory],
 	seeds: [MainSeeder],
 };


### PR DESCRIPTION
- configService 대신 dotenv 사용으로 대체함
- BaseEntity 임포트 제거
- synchronize 옵션 제거
- namingStrategy 옵션 typeorm-naming-strategies 패키지의 SnakeNamingStrategy 적용

fix-#58