### PR TITLE
feat: 예산 추천 API

### DIFF
--- a/src/budgets/budgets.controller.ts
+++ b/src/budgets/budgets.controller.ts
@@ -1,6 +1,6 @@
-import { Body, Controller, Put, UseGuards } from '@nestjs/common';
+import { Body, Controller, Get, Put, Query, UseGuards } from '@nestjs/common';
 import { BudgetsService } from './budgets.service';
-import { SetBudgetDto } from './dto';
+import { GetBudgetRecommendQueryDto, SetBudgetDto } from './dto';
 import { AccessTokenGuard } from 'src/auth';
 import { GetUser, ResponseMessage } from 'src/global';
 import { User } from 'src/users';
@@ -20,5 +20,13 @@ export class BudgetsController {
 		@GetUser() user: User,
 	) {
 		return await this.budgetsService.setBudget(setBudgetDto, user);
+	}
+
+	@Get('recommend')
+	@ResponseMessage(BudgetResponse.GET_BUDGET_RECOMMEND)
+	async getBudgetRecommend(
+		@Query() dto: GetBudgetRecommendQueryDto, //
+	) {
+		return await this.budgetsService.getBudgetRecommend(dto);
 	}
 }

--- a/src/budgets/dto/get-budget-recommend-query.dto.ts
+++ b/src/budgets/dto/get-budget-recommend-query.dto.ts
@@ -1,0 +1,8 @@
+import { Type } from 'class-transformer';
+import { IsValidAmount } from 'src/global';
+
+export class GetBudgetRecommendQueryDto {
+	@IsValidAmount('total_amount')
+	@Type(() => Number)
+	totalAmount: number;
+}

--- a/src/budgets/dto/index.ts
+++ b/src/budgets/dto/index.ts
@@ -1,1 +1,2 @@
 export * from './set-budget.dto';
+export * from './get-budget-recommend-query.dto';

--- a/src/budgets/enums/budget-response.enum.ts
+++ b/src/budgets/enums/budget-response.enum.ts
@@ -1,3 +1,4 @@
 export enum BudgetResponse {
 	SET_BUDGET = '예산 설정 성공',
+	GET_BUDGET_RECOMMEND = '예산 추천 성공',
 }

--- a/src/monthly-budgets/monthly-budgets.service.ts
+++ b/src/monthly-budgets/monthly-budgets.service.ts
@@ -24,4 +24,13 @@ export class MonthlyBudgetsService {
 	async saveOne(monthlyBudget: MonthlyBudget): Promise<MonthlyBudget> {
 		return await this.monthlyBudgetsRepository.save(monthlyBudget);
 	}
+
+	async findMany(
+		where: FindOptionsWhere<MonthlyBudget>,
+		relations?: FindOptionsRelations<MonthlyBudget>,
+		take = 10,
+		skip = 0,
+	): Promise<MonthlyBudget[]> {
+		return await this.monthlyBudgetsRepository.find({ where, take, skip, relations });
+	}
 }


### PR DESCRIPTION
- GET /budgets/recommend
- getBudgetRecommend 라우트 핸들러 추가
  - getBudgetRecommend 서비스 로직이 반환한 카테고리별 예산 추천 금액 응답
- getBudgetRecommend 서비스 로직 추가
  - 현재 년도, 월에 해당하는 50개의 월별 예산 조회(기준: 50개)
  - 각 월별 예산에 해당하는 카테고리별 예산 금액들의 퍼센트 계산
    - '음식' 또는 '생활' 카테고리의 경우 '올림'으로 퍼센트 계산
    - 나머지 카테고리의 경우 '내림'으로 퍼센트 계산
      - 퍼센트 계산 시 오차가 발생하여 카테고리별 예산 추천 금액을 계산할 때도 오차가 발생하여 유저가 전달한 총합과 카테고리별 예산 추천 금액의 총합에도 오차가 발생함
      - 이때 유저가 전달한 총합이 카테고리별 예산 추천 금액의 총합보다 항상 크게하기 위해 카테고리별로 퍼센트를 계산할 때 '올림', '내림'으로 기준을 설정하였음
  - 계산한 카테고리별 예산 금액들의 퍼센트들의 평균을 구해 카테고리별 예산 추천 금액 계산
  - 오차가 발생할 경우(유저의 총합이 카테고리별 예산 추천 금액의 총합보다 큰 경우)
    - '카페' 카테고리의 추천 금액에 오차만큼 더하여 유저의 총합과 카테고리별 예산 추천 금액의 총합을 일치시킴

feat-#27