### PR TITLE
feat: 월별 지출, 카테고리별 지출, 지출 통계 API 더미데이터 생성

### DIFF
--- a/dataSource.ts
+++ b/dataSource.ts
@@ -2,11 +2,20 @@ import { config } from 'dotenv';
 import { DataSource, DataSourceOptions } from 'typeorm';
 import { SeederOptions } from 'typeorm-extension';
 import { User } from 'src/users';
-import { MonthlyBudgetsFactory, MainSeeder, UsersFactory, CategoryBudgetsFactory } from 'src/database';
+import {
+	MonthlyBudgetsFactory,
+	MainSeeder,
+	UsersFactory,
+	CategoryBudgetsFactory,
+	CategoryExpensesFactory,
+	MonthlyExpensesFactory,
+} from 'src/database';
 import { MonthlyBudget } from 'src/monthly-budgets';
 import { CategoryBudget } from 'src/category-budgets';
 import { Category } from 'src/categories';
 import { SnakeNamingStrategy } from 'typeorm-naming-strategies';
+import { MonthlyExpense } from 'src/monthly-expenses';
+import { CategoryExpense } from 'src/category-expenses';
 
 config({
 	path: '.development.env',
@@ -19,9 +28,15 @@ const options: DataSourceOptions & SeederOptions = {
 	username: process.env.POSTGRESQL_USER,
 	password: process.env.POSTGRESQL_PASSWORD,
 	database: process.env.POSTGRESQL_DATABASE,
-	entities: [User, MonthlyBudget, CategoryBudget, Category],
+	entities: [User, MonthlyBudget, CategoryBudget, Category, MonthlyExpense, CategoryExpense],
 	namingStrategy: new SnakeNamingStrategy(),
-	factories: [UsersFactory, MonthlyBudgetsFactory, CategoryBudgetsFactory],
+	factories: [
+		UsersFactory,
+		MonthlyBudgetsFactory,
+		CategoryBudgetsFactory,
+		MonthlyExpensesFactory,
+		CategoryExpensesFactory,
+	],
 	seeds: [MainSeeder],
 };
 export const dataSource = new DataSource(options);

--- a/dataSource.ts
+++ b/dataSource.ts
@@ -9,6 +9,7 @@ import {
 	CategoryBudgetsFactory,
 	CategoryExpensesFactory,
 	MonthlyExpensesFactory,
+	UserStatsSeeder,
 } from 'src/database';
 import { MonthlyBudget } from 'src/monthly-budgets';
 import { CategoryBudget } from 'src/category-budgets';
@@ -37,6 +38,6 @@ const options: DataSourceOptions & SeederOptions = {
 		MonthlyExpensesFactory,
 		CategoryExpensesFactory,
 	],
-	seeds: [MainSeeder],
+	seeds: [MainSeeder, UserStatsSeeder],
 };
 export const dataSource = new DataSource(options);

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
 			"version": "0.0.1",
 			"license": "UNLICENSED",
 			"dependencies": {
+				"@faker-js/faker": "^8.3.1",
 				"@nestjs/common": "^9.0.0",
 				"@nestjs/config": "^3.1.1",
 				"@nestjs/core": "^9.0.0",
@@ -947,9 +948,9 @@
 			}
 		},
 		"node_modules/@faker-js/faker": {
-			"version": "8.2.0",
-			"resolved": "https://registry.npmjs.org/@faker-js/faker/-/faker-8.2.0.tgz",
-			"integrity": "sha512-VacmzZqVxdWdf9y64lDOMZNDMM/FQdtM9IsaOPKOm2suYwEatb8VkdHqOzXcDnZbk7YDE2BmsJmy/2Hmkn563g==",
+			"version": "8.3.1",
+			"resolved": "https://registry.npmjs.org/@faker-js/faker/-/faker-8.3.1.tgz",
+			"integrity": "sha512-FdgpFxY6V6rLZE9mmIBb9hM0xpfvQOSNOLnzolzKwsE1DH+gC7lEKV1p1IbR0lAYyvYd5a4u3qWJzowUkw1bIw==",
 			"funding": [
 				{
 					"type": "opencollective",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
 		"seed": "ts-node -r tsconfig-paths/register ./node_modules/typeorm-extension/bin/cli.cjs seed:run -d ./dataSource.ts"
 	},
 	"dependencies": {
+		"@faker-js/faker": "^8.3.1",
 		"@nestjs/common": "^9.0.0",
 		"@nestjs/config": "^3.1.1",
 		"@nestjs/core": "^9.0.0",

--- a/src/database/factories/category-budgets.factory.ts
+++ b/src/database/factories/category-budgets.factory.ts
@@ -5,7 +5,13 @@ export const CategoryBudgetsFactory = setSeederFactory(CategoryBudget, (faker) =
 	const categoryBudget = new CategoryBudget();
 
 	// 카테고리별 예산 금액: 10만원, 20만원, 30만원, 40만원, 50만원 중 랜덤
-	categoryBudget.amount = faker.helpers.arrayElement([100000, 200000, 300000, 400000, 500000]);
+	categoryBudget.amount = faker.helpers.weightedArrayElement([
+		{ weight: 3, value: 100000 }, // 10만원 확률 30%
+		{ weight: 3, value: 200000 }, // 20만원 확률 30%
+		{ weight: 2, value: 300000 }, // 30만원 확률 20%
+		{ weight: 1, value: 400000 }, // 40만원 확률 10%
+		{ weight: 1, value: 500000 }, // 50만원 확률 10%
+	]);
 
 	return categoryBudget;
 });

--- a/src/database/factories/category-expenses.factory.ts
+++ b/src/database/factories/category-expenses.factory.ts
@@ -9,10 +9,10 @@ export const CategoryExpensesFactory = setSeederFactory(CategoryExpense, (faker)
 	categoryExpense.date = faker.number.int({ min: 1, max: day }); // 1일부터 오늘 날짜까지
 	categoryExpense.memo = faker.word.noun(); // 랜덤 단어
 
-	const amounts: number[] = Array(50)
+	const amounts: number[] = Array(20)
 		.fill(1000)
 		.map((amount, i) => amount * (i + 1));
-	categoryExpense.amount = faker.helpers.arrayElement(amounts); // 1000원부터 5만원까지 1000원 차이의 금액 중 랜덤 선택
+	categoryExpense.amount = faker.helpers.arrayElement(amounts); // 1000원부터 20000원까지 1000원 차이의 금액 중 랜덤 선택
 	categoryExpense.excludingInTotal = faker.datatype.boolean(0.1); // true 선택 10%
 
 	return categoryExpense;

--- a/src/database/factories/category-expenses.factory.ts
+++ b/src/database/factories/category-expenses.factory.ts
@@ -1,0 +1,19 @@
+import { CategoryExpense } from 'src/category-expenses';
+import { getToday } from 'src/global';
+import { setSeederFactory } from 'typeorm-extension';
+
+export const CategoryExpensesFactory = setSeederFactory(CategoryExpense, (faker) => {
+	const categoryExpense = new CategoryExpense();
+	const { day } = getToday();
+
+	categoryExpense.date = faker.number.int({ min: 1, max: day }); // 1일부터 오늘 날짜까지
+	categoryExpense.memo = faker.word.noun(); // 랜덤 단어
+
+	const amounts: number[] = Array(50)
+		.fill(1000)
+		.map((amount, i) => amount * (i + 1));
+	categoryExpense.amount = faker.helpers.arrayElement(amounts); // 1000원부터 5만원까지 1000원 차이의 금액 중 랜덤 선택
+	categoryExpense.excludingInTotal = faker.datatype.boolean(0.1); // true 선택 10%
+
+	return categoryExpense;
+});

--- a/src/database/factories/index.ts
+++ b/src/database/factories/index.ts
@@ -1,3 +1,5 @@
 export * from './users.factory';
 export * from './monthly-budgets.factory';
 export * from './category-budgets.factory';
+export * from './category-expenses.factory';
+export * from './monthly-expenses.factory';

--- a/src/database/factories/monthly-expenses.factory.ts
+++ b/src/database/factories/monthly-expenses.factory.ts
@@ -1,0 +1,10 @@
+import { getToday } from 'src/global';
+import { MonthlyExpense } from 'src/monthly-expenses';
+import { setSeederFactory } from 'typeorm-extension';
+
+export const MonthlyExpensesFactory = setSeederFactory(MonthlyExpense, () => {
+	const monthlyExpense = new MonthlyExpense();
+	const { year } = getToday();
+	monthlyExpense.year = year; // 올해
+	return monthlyExpense;
+});

--- a/src/database/seeders/index.ts
+++ b/src/database/seeders/index.ts
@@ -1,1 +1,2 @@
 export * from './main.seeder';
+export * from './user-stats.seeder';

--- a/src/database/seeders/main.seeder.ts
+++ b/src/database/seeders/main.seeder.ts
@@ -4,16 +4,24 @@ import { User } from 'src/users';
 import { MonthlyBudget } from 'src/monthly-budgets';
 import { CategoryBudget } from 'src/category-budgets';
 import { Category } from 'src/categories';
+import { MonthlyExpense } from 'src/monthly-expenses';
+import { CategoryExpense } from 'src/category-expenses';
+import { getToday } from 'src/global';
+import { faker } from '@faker-js/faker';
 
 export class MainSeeder implements Seeder {
 	async run(dataSource: DataSource, factoryManager: SeederFactoryManager): Promise<any> {
 		const categoriesRepository = dataSource.getRepository(Category);
 		const monthlyBudgetsRepository = dataSource.getRepository(MonthlyBudget);
 		const categoryBudgetsRepository = dataSource.getRepository(CategoryBudget);
+		const monthlyExpensesRepository = dataSource.getRepository(MonthlyExpense);
+		const categoryExpensesRepository = dataSource.getRepository(CategoryExpense);
 
 		const usersFactory = factoryManager.get(User);
 		const monthlyBudgetsFactory = factoryManager.get(MonthlyBudget);
 		const categoryBudgetsFactory = factoryManager.get(CategoryBudget);
+		const monthlyExpensesFactory = factoryManager.get(MonthlyExpense);
+		const categoryExpensesFactory = factoryManager.get(CategoryExpense);
 
 		// 랜덤 유저 10명 저장
 		const users = await usersFactory.saveMany(10);
@@ -51,12 +59,64 @@ export class MainSeeder implements Seeder {
 				// 랜덤 카테고리별 예산 저장
 				await categoryBudgetsRepository.save(fakeCategoryBudgets);
 
-				// 월별 예산 전첵 금액 업데이트
+				// 월별 예산 전체 금액 업데이트
 				monthlyBudget.totalAmount = totalAmount;
 			}),
 		);
 
 		// 월별 예산 저장
 		await monthlyBudgetsRepository.save(monthlyBudgets);
+
+		// 랜덤 월별 지출 10개 생성
+		const { month, day } = getToday();
+		const fakeMonthlyExpenses = await Promise.all(
+			Array(10)
+				.fill('')
+				.map(async (_, i) => {
+					const fakeUser = users[i];
+					return await monthlyExpensesFactory.make({
+						user: fakeUser,
+						totalAmount: 0,
+						month,
+					});
+				}),
+		);
+		// 랜덤 월별 지출 10개 저장
+		const monthlyExpenses = await monthlyExpensesRepository.save(fakeMonthlyExpenses);
+
+		await Promise.all(
+			monthlyExpenses.map(async (monthlyExpense) => {
+				// 랜덤 카테고리별 지출 생성
+				const fakeCategoryExpenses: CategoryExpense[] = [];
+				for (let i = 0; i < day; i += 3) {
+					fakeCategoryExpenses.push(
+						...(await Promise.all(
+							categories.map(async (category) => {
+								return await categoryExpensesFactory.make({
+									category,
+									monthlyExpense,
+									date: faker.number.int({ min: 1, max: day }),
+								});
+							}),
+						)),
+					);
+				}
+
+				// 카테고리별 지출 전체 금액 계산
+				const totalAmount = fakeCategoryExpenses.reduce(
+					(prev, curr) => (prev += curr.excludingInTotal ? 0 : curr.amount),
+					0,
+				);
+
+				// 랜덤 카테고리별 지출 저장
+				await categoryExpensesRepository.save(fakeCategoryExpenses);
+
+				// 월별 지출 전체 금액 업데이트
+				monthlyExpense.totalAmount = totalAmount;
+			}),
+		);
+
+		// 월별 지출 저장
+		await monthlyExpensesRepository.save(monthlyExpenses);
 	}
 }

--- a/src/database/seeders/main.seeder.ts
+++ b/src/database/seeders/main.seeder.ts
@@ -7,7 +7,6 @@ import { Category } from 'src/categories';
 import { MonthlyExpense } from 'src/monthly-expenses';
 import { CategoryExpense } from 'src/category-expenses';
 import { getToday } from 'src/global';
-import { faker } from '@faker-js/faker';
 
 export class MainSeeder implements Seeder {
 	async run(dataSource: DataSource, factoryManager: SeederFactoryManager): Promise<any> {
@@ -88,14 +87,14 @@ export class MainSeeder implements Seeder {
 			monthlyExpenses.map(async (monthlyExpense) => {
 				// 랜덤 카테고리별 지출 생성
 				const fakeCategoryExpenses: CategoryExpense[] = [];
-				for (let i = 0; i < day; i += 3) {
+				for (let date = 1; date <= day; date += 1) {
 					fakeCategoryExpenses.push(
 						...(await Promise.all(
 							categories.map(async (category) => {
 								return await categoryExpensesFactory.make({
 									category,
 									monthlyExpense,
-									date: faker.number.int({ min: 1, max: day }),
+									date,
 								});
 							}),
 						)),

--- a/src/database/seeders/user-stats.seeder.ts
+++ b/src/database/seeders/user-stats.seeder.ts
@@ -1,0 +1,127 @@
+import { Category } from 'src/categories';
+import { CategoryBudget } from 'src/category-budgets';
+import { CategoryExpense } from 'src/category-expenses';
+import { getToday } from 'src/global';
+import { MonthlyBudget } from 'src/monthly-budgets';
+import { MonthlyExpense } from 'src/monthly-expenses';
+import { User } from 'src/users';
+import { DataSource } from 'typeorm';
+import { Seeder, SeederFactoryManager } from 'typeorm-extension';
+
+export class UserStatsSeeder implements Seeder {
+	async run(dataSource: DataSource, factoryManager: SeederFactoryManager): Promise<any> {
+		const monthlyBudgetsRepository = dataSource.getRepository(MonthlyBudget);
+		const categoryBudgetsRepository = dataSource.getRepository(CategoryBudget);
+		const monthlyExpensesRepository = dataSource.getRepository(MonthlyExpense);
+		const categoryExpensesRepository = dataSource.getRepository(CategoryExpense);
+		const categoriesRepository = dataSource.getRepository(Category);
+
+		const usersFactory = factoryManager.get(User);
+		const monthlyBudgetsFactory = factoryManager.get(MonthlyBudget);
+		const categoryBudgetsFactory = factoryManager.get(CategoryBudget);
+		const monthlyExpensesFactory = factoryManager.get(MonthlyExpense);
+		const categoryExpensesFactory = factoryManager.get(CategoryExpense);
+
+		const categories = await categoriesRepository.find();
+		const user = await usersFactory.save();
+		const { month, day } = getToday();
+
+		// 지난 달 월별 예산 생성 및 저장
+		const fakeLastMonthlyBudget = await monthlyBudgetsFactory.make({ totalAmount: 0, month: month - 1, user });
+		const lastMonthlyBudget = await monthlyBudgetsRepository.save(fakeLastMonthlyBudget);
+
+		// 지난 달 카테고리별 예산 생성 및 저장
+		const fakeLastMonthlyCategoryBudgets = await Promise.all(
+			categories.map(
+				async (category) => await categoryBudgetsFactory.make({ category, monthlyBudget: lastMonthlyBudget }),
+			),
+		);
+		await categoryBudgetsRepository.save(fakeLastMonthlyCategoryBudgets);
+
+		// 지난 달 월별 예산 전체 금액 업데이트 후 저장
+		const lastMonthlyBudgetTotalAmount = fakeLastMonthlyCategoryBudgets.reduce(
+			(prev, curr) => (prev += curr.amount),
+			0,
+		);
+		lastMonthlyBudget.totalAmount = lastMonthlyBudgetTotalAmount;
+		await monthlyBudgetsRepository.save(lastMonthlyBudget);
+
+		// 이번 달 월별 예산 생성 및 저장
+		const fakeThisMonthlyBudget = await monthlyBudgetsFactory.make({ totalAmount: 0, month, user });
+		const thisMonthlyBudget = await monthlyBudgetsRepository.save(fakeThisMonthlyBudget);
+
+		// 이번 달 카테고리별 예산 생성 및 저장
+		const fakeThisMonthlyCategoryBudgets = await Promise.all(
+			categories.map(
+				async (category) => await categoryBudgetsFactory.make({ category, monthlyBudget: thisMonthlyBudget }),
+			),
+		);
+		await categoryBudgetsRepository.save(fakeThisMonthlyCategoryBudgets);
+
+		// 이번 달 월별 예산 전체 금액 업데이트 후 저장
+		const thisMonthlyBudgetTotalAmount = fakeThisMonthlyCategoryBudgets.reduce(
+			(prev, curr) => (prev += curr.amount),
+			0,
+		);
+		thisMonthlyBudget.totalAmount = thisMonthlyBudgetTotalAmount;
+		await monthlyBudgetsRepository.save(thisMonthlyBudget);
+
+		// 지난 달 월별 지출 생성 및 저장
+		const fakeLastMonthlyExpense = await monthlyExpensesFactory.make({ totalAmount: 0, month: month - 1, user });
+		const lastMonthlyExpense = await monthlyExpensesRepository.save(fakeLastMonthlyExpense);
+
+		// 지난 달 전체 카테고리별 지출 생성 및 저장
+		//    1일부터 30일까지 하루마다 카테고리별 지출 생성
+		const fakeLastMonthlyCategoryExpenses: CategoryExpense[] = [];
+		for (let date = 1; date <= 30; date += 1) {
+			const fakeCategoryExpensesAtDate = await Promise.all(
+				categories.map(async (category) => {
+					return await categoryExpensesFactory.make({
+						category,
+						monthlyExpense: lastMonthlyExpense,
+						date,
+					});
+				}),
+			);
+			fakeLastMonthlyCategoryExpenses.push(...fakeCategoryExpensesAtDate);
+		}
+		await categoryExpensesRepository.save(fakeLastMonthlyCategoryExpenses);
+
+		// 지난 달 월별 지출 전체 금액 업데이트 후 저장
+		const lastMonthlyExpenseTotalAmount = fakeLastMonthlyCategoryExpenses.reduce(
+			(prev, curr) => (prev += curr.excludingInTotal ? 0 : curr.amount),
+			0,
+		);
+		lastMonthlyExpense.totalAmount = lastMonthlyExpenseTotalAmount;
+		await monthlyExpensesRepository.save(lastMonthlyExpense);
+
+		// 이번 달 월별 지출 생성 및 저장
+		const fakeThisMonthlyExpense = await monthlyExpensesFactory.make({ totalAmount: 0, month, user });
+		const thisMonthlyExpense = await monthlyExpensesRepository.save(fakeThisMonthlyExpense);
+
+		// 이번 달 오늘까지의 카테고리별 지출 생성 및 저장
+		//    1일부터 오늘까지 하루마다 카테고리별 지출 생성
+		const fakeThisMonthlyCategoryExpenses: CategoryExpense[] = [];
+		for (let date = 1; date <= day; date += 1) {
+			const fakeCategoryExpensesAtDate = await Promise.all(
+				categories.map(async (category) => {
+					return await categoryExpensesFactory.make({
+						category,
+						monthlyExpense: thisMonthlyExpense,
+						date,
+					});
+				}),
+			);
+			fakeThisMonthlyCategoryExpenses.push(...fakeCategoryExpensesAtDate);
+		}
+		await categoryExpensesRepository.save(fakeThisMonthlyCategoryExpenses);
+
+		// 이번 달 월별 지출 전체 금액 업데이트 후 저장
+		const thisMonthlyExpenseTotalAmount = fakeThisMonthlyCategoryExpenses.reduce(
+			(prev, curr) => (prev += curr.excludingInTotal ? 0 : curr.amount),
+			0,
+		);
+		thisMonthlyExpense.totalAmount = thisMonthlyExpenseTotalAmount;
+		await monthlyExpensesRepository.save(thisMonthlyExpense);
+	}
+}


### PR DESCRIPTION
월별 지출, 카테고리별 지출 더미데이터 생성
- 랜덤 월별 지출 10개 생성 및 저장
- 각 월별 지출마다 랜덤 카테고리별 지출 생성 및 저장
  - 각 카테고리별로 하루 간격으로 생성

지출 통계 API를 위한 더미데이터 생성
- 지난 달 월별 예산, 카테고리별 예산 생성
- 이번 달 월별 예산, 카테고리별 예산 생성
- 지난 달 월별 지출, 카테고리별 지출 생성
  - 1일부터 30일까지 하루 간격으로 각 카테고리별 지출 생성
- 이번 달 월별 지출, 카테고리별 지출 생성
  - 1일부터 오늘까지 하루 간격으로 각 카테고리별 지출 생성

feat-#61