### PR TITLE
feat: 지출 통계 API

### DIFF
--- a/src/expenses/enums/expense-exception.enum.ts
+++ b/src/expenses/enums/expense-exception.enum.ts
@@ -10,4 +10,5 @@ export enum ExpenseException {
 	BUDGET_NOT_FOUND = '예산이 존재하지 않습니다.',
 	CANNOT_MAKE_TODAY_SUMMARY = '오늘 지출 안내 내용을 생성할 수 없습니다.',
 	CANNOT_MAKE_TODAY_RECOMMEND = '오늘 지출 추천 내용을 생성할 수 없습니다.',
+	CANNOT_MAKE_STATS = '지출 통계를 생성할 수 없습니다.',
 }

--- a/src/expenses/enums/expense-response.enum.ts
+++ b/src/expenses/enums/expense-response.enum.ts
@@ -6,4 +6,5 @@ export enum ExpenseResponse {
 	GET_EXPENSES = '지출 기록 목록 조회 성공',
 	GET_TODAY_EXPENSES_SUMMARY = '오늘 지출 안내 성공',
 	GET_TODAY_EXPENSES_RECOMMEND = '오늘 지출 추천 성공',
+	GET_EXPENSES_STATS = '지출 통계 조회 성공',
 }

--- a/src/expenses/expenses.controller.ts
+++ b/src/expenses/expenses.controller.ts
@@ -7,13 +7,12 @@ import { ExpenseResponse } from './enums';
 import { AccessTokenGuard } from 'src/auth';
 import { InvalidParseUUIDPipe } from './pipes';
 import { GetExpensesQueryDtoPipe } from './pipes/get-expenses-query-dto.pipe';
+import { StatsService } from './stats.service';
 
 @Controller('expenses')
 @UseGuards(AccessTokenGuard)
 export class ExpensesController {
-	constructor(
-		private readonly expensesService: ExpensesService, //
-	) {}
+	constructor(private readonly expensesService: ExpensesService, private readonly statsService: StatsService) {}
 
 	@Post()
 	@ResponseMessage(ExpenseResponse.CREATE_EXPENSE)
@@ -66,6 +65,14 @@ export class ExpensesController {
 		@GetUser() user: User, //
 	) {
 		return await this.expensesService.getTodayExpensesRecommend(user);
+	}
+
+	@Get('stats')
+	@ResponseMessage(ExpenseResponse.GET_EXPENSES_STATS)
+	async getExpensesStats(
+		@GetUser() user: User, //
+	) {
+		return await this.statsService.getExpensesStats(user);
 	}
 
 	@Get(':id')

--- a/src/expenses/expenses.module.ts
+++ b/src/expenses/expenses.module.ts
@@ -6,9 +6,18 @@ import { CategoryExpensesModule } from 'src/category-expenses';
 import { CategoriesModule } from 'src/categories';
 import { MonthlyBudgetsModule } from 'src/monthly-budgets';
 import { StatsService } from './stats.service';
+import { UsersModule } from 'src/users';
+import { CategoryBudgetsModule } from 'src/category-budgets';
 
 @Module({
-	imports: [MonthlyExpensesModule, CategoryExpensesModule, CategoriesModule, MonthlyBudgetsModule],
+	imports: [
+		MonthlyExpensesModule,
+		CategoryExpensesModule,
+		CategoriesModule,
+		MonthlyBudgetsModule,
+		CategoryBudgetsModule,
+		UsersModule,
+	],
 	controllers: [ExpensesController],
 	providers: [ExpensesService, StatsService],
 })

--- a/src/expenses/expenses.module.ts
+++ b/src/expenses/expenses.module.ts
@@ -5,10 +5,11 @@ import { MonthlyExpensesModule } from 'src/monthly-expenses';
 import { CategoryExpensesModule } from 'src/category-expenses';
 import { CategoriesModule } from 'src/categories';
 import { MonthlyBudgetsModule } from 'src/monthly-budgets';
+import { StatsService } from './stats.service';
 
 @Module({
 	imports: [MonthlyExpensesModule, CategoryExpensesModule, CategoriesModule, MonthlyBudgetsModule],
 	controllers: [ExpensesController],
-	providers: [ExpensesService],
+	providers: [ExpensesService, StatsService],
 })
 export class ExpensesModule {}

--- a/src/expenses/stats.service.ts
+++ b/src/expenses/stats.service.ts
@@ -1,0 +1,8 @@
+import { Injectable } from '@nestjs/common';
+
+@Injectable()
+export class StatsService {
+	async getExpensesStats() {
+		return StatsService.name;
+	}
+}

--- a/src/expenses/stats.service.ts
+++ b/src/expenses/stats.service.ts
@@ -1,8 +1,212 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, UnprocessableEntityException } from '@nestjs/common';
+import { CategoryExpensesService } from 'src/category-expenses';
+import {
+	CategoryAndRatio,
+	CategoryAndSum,
+	CategoryName,
+	getLastMonthDate,
+	getLastWeekDate,
+	getToday,
+} from 'src/global';
+import { MonthlyExpensesService } from 'src/monthly-expenses';
+import { User, UsersService } from 'src/users';
+import { ExpenseException } from './enums';
 
 @Injectable()
 export class StatsService {
-	async getExpensesStats() {
-		return StatsService.name;
+	constructor(
+		private readonly monthlyExpensesService: MonthlyExpensesService,
+		private readonly categoryExpensesService: CategoryExpensesService,
+		private readonly usersService: UsersService,
+	) {}
+
+	async getExpensesStats(user: User) {
+		const { year, month, day } = getToday();
+		const { year: lastMonthYear, month: lastMonth } = getLastMonthDate({ year, month });
+
+		// 요청 유저의 지난 달 월별 지출
+		const currentUserLastMonthlyExpense = await this.monthlyExpensesService.findOne({
+			year: lastMonthYear,
+			month: lastMonth,
+			user: { id: user.id },
+		});
+		if (!currentUserLastMonthlyExpense) {
+			throw new UnprocessableEntityException(
+				`지난 달 월별 ${ExpenseException.NOT_FOUND} ${ExpenseException.CANNOT_MAKE_STATS}`,
+			);
+		}
+
+		// 요청 유저의 이번 달 월별 지출
+		const currentUserThisMonthlyExpense = await this.monthlyExpensesService.findOne({
+			year,
+			month,
+			user: { id: user.id },
+		});
+		if (!currentUserThisMonthlyExpense) {
+			throw new UnprocessableEntityException(
+				`이번 달 월별 ${ExpenseException.NOT_FOUND}, ${ExpenseException.CANNOT_MAKE_STATS}`,
+			);
+		}
+
+		// 지난 달 오늘까지의 각 카테고리별 지출 합계, 이번 달 오늘 날짜까지의 각 카테고리별 지출 합계
+		const lastMonthlyExpensesAmountSums = await this.categoryExpensesService.getAmountSumsUntilDate(
+			day,
+			currentUserLastMonthlyExpense.id,
+		);
+		const thisMonthlyExpensesAmountSums = await this.categoryExpensesService.getAmountSumsUntilDate(
+			day,
+			currentUserThisMonthlyExpense.id,
+		);
+
+		// 지난 달 대비 총액 소비율, 카테고리별 소비율 계산
+		const totalConsumptionRatioCompareToLastMonth = this.getTotalAmountConsumptionRatio(
+			lastMonthlyExpensesAmountSums,
+			thisMonthlyExpensesAmountSums,
+		);
+		const categoryConsumptionRatioCompareToLastMonth = this.getCategoryAmountConsumptionRatio(
+			lastMonthlyExpensesAmountSums,
+			thisMonthlyExpensesAmountSums,
+		);
+
+		const { month: lastWeekMonth, day: lastWeekDay } = getLastWeekDate({ year, month, day });
+
+		// 일주일 전의 각 카테고리별 지출 합계, 오늘의 각 카테고리별 지출 합계
+		const lastWeeklyExpensesAmountSums = await this.categoryExpensesService.getAmountSumsAtDate(
+			lastWeekDay,
+			lastWeekMonth === month ? currentUserThisMonthlyExpense.id : currentUserLastMonthlyExpense.id,
+		);
+		const todayExpensesAmountSums = await this.categoryExpensesService.getAmountSumsAtDate(
+			day,
+			currentUserThisMonthlyExpense.id,
+		);
+
+		// 지난 주 대비 총액 소비율, 카테고리별 소비율 계산
+		const totalConsumptionRatioCompareToLastWeek = this.getTotalAmountConsumptionRatio(
+			lastWeeklyExpensesAmountSums,
+			todayExpensesAmountSums,
+		);
+		const categoryConsumptionRatioCompareToLastWeek = this.getCategoryAmountConsumptionRatio(
+			lastWeeklyExpensesAmountSums,
+			todayExpensesAmountSums,
+		);
+
+		// 이번 달 월별 예산과 월별 지출을 가지고 있는 랜덤 유저의 id 조회
+		const randomUserId = await this.usersService.findRandomOneId(user.id, { year, month });
+
+		// 랜덤 유저의 이번 달 월별 예산 대비 월별 지출 비율 조회
+		const {
+			monthlyExpenseId: randomUserThisMonthlyExpenseId,
+			monthlyBudgetId: randomUserThisMonthlyBudgetId,
+			ratio: randomUserTotalAmountRatio,
+		} = await this.monthlyExpensesService.getTotalAmountConsumptionRatio(randomUserId, { year, month });
+
+		// 요청 유저의 이번 달 월별 예산 대비 월별 지출 비율 조회
+		const {
+			monthlyExpenseId: currentUserThisMonthlyExpenseId,
+			monthlyBudgetId: currentUserThisMonthlyBudgetId,
+			ratio: currentUserTotalAmountRatio,
+		} = await this.monthlyExpensesService.getTotalAmountConsumptionRatio(user.id, { year, month });
+
+		// 랜덤 유저의 전체 지출 비율 대비 요청 유저의 전체 지출 비율의 소비율 계산
+		// 		요청 유저의 지출 비율: 60%
+		//		랜덤 유저의 지출 비율: 50%
+		//		소비율: 60% / 50% * 100
+		const totalConsumptionRatioCompareToRandomUser = this.calculateConsumptionRatio(
+			currentUserTotalAmountRatio,
+			randomUserTotalAmountRatio,
+		);
+
+		// 랜덤 유저의 이번 달 카테고리별 예산 대비 카테고리별 지출 비율 조회
+		const randomUserCategoryConsumptionRatios = await this.categoryExpensesService.getCategoryConsumptionRatio(
+			day,
+			randomUserThisMonthlyExpenseId,
+			randomUserThisMonthlyBudgetId,
+		);
+
+		// 요청 유저의 이번 달 카테고리별 예산 대비 카테고리별 지출 비율 조회
+		const currentUserCategoryConsumptionRatios = await this.categoryExpensesService.getCategoryConsumptionRatio(
+			day,
+			currentUserThisMonthlyExpenseId,
+			currentUserThisMonthlyBudgetId,
+		);
+
+		// 랜덤 유저의 카테고리별 지출 비율 대비 요청 유저의 카테고리별 지출 비율의 소비율 계산
+		//		요청 유저의 카테고리별 지출 비율: 60%
+		//		랜덤 유저의 카테고리별 지출 비율: 50%
+		//		소비율: 60% / 50% * 100
+		const categoryConsumptionRatioCompareToRandomUser: CategoryAndRatio[] = [];
+		randomUserCategoryConsumptionRatios.forEach((randomUserCategoryConsumptionRatio) => {
+			const category = randomUserCategoryConsumptionRatio.category;
+			const randomUserRatio = randomUserCategoryConsumptionRatio.ratio;
+			const { ratio: currentUserRatio } = currentUserCategoryConsumptionRatios.find(
+				(value) => value.category === category,
+			);
+			const categoryConsumptionRatio = this.calculateConsumptionRatio(currentUserRatio, randomUserRatio);
+			categoryConsumptionRatioCompareToRandomUser.push({ category, ratio: categoryConsumptionRatio });
+		});
+
+		return {
+			last_month: {
+				total_consumption_ratio: totalConsumptionRatioCompareToLastMonth,
+				category_consumption_ratio: categoryConsumptionRatioCompareToLastMonth,
+			},
+			last_week: {
+				total_consumption_ratio: totalConsumptionRatioCompareToLastWeek,
+				category_consumption_ratio: categoryConsumptionRatioCompareToLastWeek,
+			},
+			other_user: {
+				total_consumption_ratio: totalConsumptionRatioCompareToRandomUser,
+				category_consumption_ratio: categoryConsumptionRatioCompareToRandomUser,
+			},
+		};
+	}
+
+	getTotalAmountConsumptionRatio(
+		lastExpensesAmountSums: CategoryAndSum[],
+		currentExpensesAmountSums: CategoryAndSum[],
+	): number | null {
+		const currentExpensesTotalAmount = currentExpensesAmountSums.reduce((prev, curr) => (prev += curr.sum), 0);
+		const lastExpensesTotalAmount = lastExpensesAmountSums.reduce((prev, curr) => (prev += curr.sum), 0);
+		const ratio = this.calculateConsumptionRatio(currentExpensesTotalAmount, lastExpensesTotalAmount);
+		return ratio;
+	}
+
+	getCategoryAmountConsumptionRatio(
+		lastExpensesAmountSums: CategoryAndSum[],
+		currentExpensesAmountSums: CategoryAndSum[],
+	): CategoryAndRatio[] {
+		const categoryNames = Object.values(CategoryName);
+		const currentCategoryAmountSums = {};
+		const lastCategoryAmountSums = {};
+		const categoryAmountConsumptionRatios: CategoryAndRatio[] = [];
+
+		categoryNames.forEach((category) => {
+			currentCategoryAmountSums[category] = 0;
+			lastCategoryAmountSums[category] = 0;
+		});
+
+		currentExpensesAmountSums.forEach(
+			(categoryAndSum) => (currentCategoryAmountSums[categoryAndSum.category] = categoryAndSum.sum),
+		);
+		lastExpensesAmountSums.forEach(
+			(categoryAndSum) => (lastCategoryAmountSums[categoryAndSum.category] = categoryAndSum.sum),
+		);
+
+		for (const category in currentCategoryAmountSums) {
+			const currentCategoryAmountSum = currentCategoryAmountSums[category];
+			const lastCategoryAmountSum = lastCategoryAmountSums[category];
+			const ratio = this.calculateConsumptionRatio(currentCategoryAmountSum, lastCategoryAmountSum);
+
+			categoryAmountConsumptionRatios.push({
+				category,
+				ratio,
+			});
+		}
+
+		return categoryAmountConsumptionRatios;
+	}
+
+	calculateConsumptionRatio(numerator: number, denominator: number): number | null {
+		return denominator !== 0 ? Math.round((numerator / denominator) * 100) : null;
 	}
 }

--- a/src/global/interfaces/category-and-ratio.ts
+++ b/src/global/interfaces/category-and-ratio.ts
@@ -1,0 +1,4 @@
+export interface CategoryAndRatio {
+	category: string;
+	ratio: number | null;
+}

--- a/src/global/interfaces/category-and-sum.ts
+++ b/src/global/interfaces/category-and-sum.ts
@@ -1,0 +1,4 @@
+export interface CategoryAndSum {
+	category: string;
+	sum: number;
+}

--- a/src/global/interfaces/index.ts
+++ b/src/global/interfaces/index.ts
@@ -1,2 +1,5 @@
 export * from './token.payload';
 export * from './year-month-day';
+export * from './category-and-sum';
+export * from './category-and-ratio';
+export * from './total-amount-ratio';

--- a/src/global/interfaces/ratio.ts
+++ b/src/global/interfaces/ratio.ts
@@ -1,0 +1,3 @@
+export interface Ratio {
+	ratio: number;
+}

--- a/src/global/interfaces/ratio.ts
+++ b/src/global/interfaces/ratio.ts
@@ -1,3 +1,0 @@
-export interface Ratio {
-	ratio: number;
-}

--- a/src/global/interfaces/total-amount-ratio.ts
+++ b/src/global/interfaces/total-amount-ratio.ts
@@ -1,0 +1,5 @@
+export interface TotalAmountRatio {
+	monthlyExpenseId: string;
+	monthlyBudgetId: string;
+	ratio: number;
+}

--- a/src/global/utils/get-last-month-date.ts
+++ b/src/global/utils/get-last-month-date.ts
@@ -1,0 +1,5 @@
+import { YearMonthDay } from '../interfaces';
+
+export function getLastMonthDate({ year, month }: Omit<YearMonthDay, 'day'>): Omit<YearMonthDay, 'day'> {
+	return month === 1 ? { year: year - 1, month: 12 } : { year, month: month - 1 };
+}

--- a/src/global/utils/get-last-week-date.ts
+++ b/src/global/utils/get-last-week-date.ts
@@ -1,0 +1,31 @@
+import { YearMonthDay } from '../interfaces';
+
+export function getLastWeekDate({ year, month, day }: YearMonthDay): YearMonthDay {
+	const lastWeekDate = day - 7;
+	const isMonthJanuary = month === 1;
+
+	if (lastWeekDate < 0 && isMonthJanuary) {
+		const lastWeek = new Date(year - 1, 12, lastWeekDate);
+		return {
+			year: lastWeek.getFullYear(),
+			month: lastWeek.getMonth() + 1,
+			day: lastWeek.getDate(),
+		};
+	}
+
+	if (lastWeekDate < 0) {
+		const lastWeek = new Date(year, month - 1, lastWeekDate);
+		return {
+			year: lastWeek.getFullYear(),
+			month: lastWeek.getMonth() + 1,
+			day: lastWeek.getDate(),
+		};
+	}
+
+	const lastWeek = new Date(year, month - 1, lastWeekDate);
+	return {
+		year: lastWeek.getFullYear(),
+		month: lastWeek.getMonth() + 1,
+		day: lastWeek.getDate(),
+	};
+}

--- a/src/global/utils/index.ts
+++ b/src/global/utils/index.ts
@@ -3,3 +3,4 @@ export * from './get-total-amount';
 export * from './get-lowercase-category-name-enum-key';
 export * from './get-today';
 export * from './get-last-week-date';
+export * from './get-last-month-date';

--- a/src/global/utils/index.ts
+++ b/src/global/utils/index.ts
@@ -2,3 +2,4 @@ export * from './get-date';
 export * from './get-total-amount';
 export * from './get-lowercase-category-name-enum-key';
 export * from './get-today';
+export * from './get-last-week-date';

--- a/src/monthly-expenses/monthly-expenses.service.ts
+++ b/src/monthly-expenses/monthly-expenses.service.ts
@@ -4,7 +4,7 @@ import { MonthlyExpense } from './entity';
 import { FindOptionsRelations, FindOptionsWhere, Repository } from 'typeorm';
 import { GetExpensesQueryDto } from 'src/expenses';
 import { User } from 'src/users';
-import { YearMonthDay } from 'src/global';
+import { Ratio, YearMonthDay } from 'src/global';
 
 @Injectable()
 export class MonthlyExpensesService {
@@ -65,5 +65,29 @@ export class MonthlyExpensesService {
 		}
 
 		return await qb.getMany();
+	}
+
+	async getTotalAmountConsumptionRatio(userId: string, { year, month }: Omit<YearMonthDay, 'day'>): Promise<number> {
+		const [{ ratio }] = (await this.monthlyExpensesRepository.query(`
+			SELECT
+					round(me.total_amount::numeric / mb.total_amount::numeric * 100)::int as ratio
+			FROM
+					monthly_expense me,
+					(
+							SELECT
+									mb.total_amount
+							FROM
+									monthly_budget mb
+							WHERE
+									mb.year = ${year}
+									AND mb.month = ${month}
+									AND mb.user_id = '${userId}'
+					) as mb
+			WHERE
+					me.year = ${year}
+					AND me.month = ${month}
+					AND me.user_id = '${userId}'
+		`)) as Ratio[];
+		return ratio;
 	}
 }

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -31,8 +31,8 @@ export class UsersService {
 		return await this.usersRepository.findOne({ where });
 	}
 
-	async findRandomOneId(userId: string, { year, month }: Omit<YearMonthDay, 'day'>): Promise<Pick<User, 'id'>[]> {
-		const randomOneId = await this.usersRepository.query(
+	async findRandomOneId(userId: string, { year, month }: Omit<YearMonthDay, 'day'>): Promise<string> {
+		const [{ id }] = (await this.usersRepository.query(
 			`SELECT
 					id
 			FROM
@@ -51,8 +51,8 @@ export class UsersService {
 				)
 			ORDER BY RANDOM()
 			LIMIT 1`,
-		);
-		return randomOneId;
+		)) as Pick<User, 'id'>[];
+		return id;
 	}
 
 	async updateOne(where: FindOptionsWhere<User>, user: Partial<User>) {


### PR DESCRIPTION
- GET /expenses/stats
- getExpensesStats 라우트 핸들러 추가
  - 통계 서비스의 getExpensesStats 서비스 로직이 반환한 지출 통계 응답
- getExpensesStats 서비스 로직 추가
  - 요청 유저의 지난 달 대비 이번 달의 총액, 카테고리별 소비율 계산
    - 카테고리별 서비스의 getAmountSumsUntilDate 서비스 로직(SQL raw 쿼리)를 사용하여 카테고리별 지출 총액 계산
	- 통계 서비스의 getTotalAmountConsumptionRatio 서비스 로직을 사용하여 총액 소비율 계산
	- 통계 서비스의 getCategoryAmountConsumptionRatio 서비스 로직을 사용하여 카테고리별 소비율 계산
  - 요청 유저의 지난 주(요일) 대비 이번 주의 총액, 카테고리별 소비율 계산
    - 카테고리별 서비스의 getAmountSumsAtDate 서비스 로직(SQL raw 쿼리)를 사용하여 카테고리별 지출 총액 계산
	- 통계 서비스의 getTotalAmountConsumptionRatio 서비스 로직을 사용하여 총액 소비율 계산
	- 통계 서비스의 getCategoryAmountConsumptionRatio 서비스 로직을 사용하여 카테고리별 소비율 계산
  - 랜덤 유저 대비 요청 유저의 총액, 카테고리별 소비율 계산
    - 랜덤 유저와 요청 유저에 대해 카테고리별 서비스의 getCategoryConsumptionRatio 서비스 로직(SQL raw 쿼리)를 사용하여 카테고리별 지출 총액 대비 카테고리별 예산 비율 계산
	- 통계 서비스 코드를 통해 랜덤 유저 대비 요청 유저의 총액, 카테고리별 소비율 계산

feat-#62